### PR TITLE
Spotbugs reporting fixes

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,3 +20,4 @@ atlassian-ide-plugin.xml
 node
 node_modules
 core.email.components.commons.datalayer.*
+/.java-version

--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -42,6 +42,16 @@
     <build>
         <plugins>
             <plugin>
+                <groupId>org.apache.rat</groupId>
+                <artifactId>apache-rat-plugin</artifactId>
+                <configuration>
+                    <excludes combine.children="append">
+                        <!-- Ignore lint-files -->
+                        <exclude>**/resources/css/*</exclude>
+                    </excludes>
+                </configuration>
+            </plugin>
+            <plugin>
                 <groupId>org.apache.felix</groupId>
                 <artifactId>maven-bundle-plugin</artifactId>
                 <extensions>true</extensions>

--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/css/CssInliner.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/css/CssInliner.java
@@ -1,3 +1,18 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.email.core.components.internal.css;
 
 import java.util.HashMap;
@@ -42,14 +57,15 @@ public class CssInliner {
     }
 
     private String getOutputHtml(Document document, Map<String, String> selectorMap) {
-        for (String selector : selectorMap.keySet()) {
+        for (Map.Entry<String, String> entry : selectorMap.entrySet()) {
+            String selector = entry.getKey();
             Elements selectedElements = document.select(selector);
             for (Element selectedElement : selectedElements) {
                 String styleAttribute = selectedElement.attr(STYLE_ATTR);
                 if (StringUtils.isNotEmpty(styleAttribute)) {
                     selectedElement.attr(STYLE_ATTR, concatenateProperties(styleAttribute, selectorMap.get(selector)));
                 } else {
-                    selectedElement.attr(STYLE_ATTR, selectorMap.get(selector));
+                    selectedElement.attr(STYLE_ATTR, entry.getValue());
                 }
             }
         }

--- a/bundles/core/src/test/java/com/adobe/cq/email/core/components/internal/css/CssInlinerTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/email/core/components/internal/css/CssInlinerTest.java
@@ -1,3 +1,18 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.email.core.components.internal.css;
 
 import java.io.IOException;

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,7 @@
                         <exclude>**/*.editorconfig</exclude>
                         <exclude>**/*.stylelintrc.yaml</exclude>
                         <exclude>**/*.eslintignore</exclude>
+                        <exclude>.java-version</exclude>
                     </excludes>
                 </configuration>
             </plugin>


### PR DESCRIPTION
CSS Inliner rewriter Spotbugs error fixes

## Description

Installing the project the following error occurs:

> Medium: com.adobe.cq.email.core.components.internal.css.CssInliner.getOutputHtml(Document, Map) makes inefficient use of keySet iterator instead of entrySet iterator [com.adobe.cq.email.core.components.internal.css.CssInliner] At CssInliner.java:[line 50] WMI_WRONG_MAP_ITERATOR

## Related Issue

[https://github.com/adobe/aem-core-email-components/issues/2](url)

## Motivation and Context

Fixes of bugs found by Spotbug on project installation

## How Has This Been Tested?

1. Executed **mvn clean install**
2. Identified the warning 
3. Changed the code in CssInliner.java class
4. Ran again the specific jUnit test (successfully)
5. Ran again **mvn clean install** (successfully)

## Types of changes

Instead of iterating over a Map calling _keySet_ method (and then retrieving the related value by accessing the map again with this key), the outer loop has been changed to call the _entrySet_ method. The pre-existing jUnit test ensures that the output is the same.

Some changes were needed to **apache-rat-plugin** (just to exclude test resources and the root .java-version file from checks).
Also added an entry to the global .gitignore file (.java-version file in the root directory)

## Checklist:

- [X] My code follows the code style of this project.
- [X] All new and existing tests passed.
