### PR TITLE
jUnit test fixes on Windows-like machines

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/css/CssInliner.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/css/CssInliner.java
@@ -50,8 +50,7 @@ public class CssInliner {
         Elements elements = document.select(STYLE_ELM);
         StringBuilder stringBuilder = new StringBuilder();
         for (Element element : elements) {
-            stringBuilder.append(element.getAllElements().get(0).data().replaceAll(
-                    "\n", "").replaceAll(" +", " ").trim());
+            stringBuilder.append(element.getAllElements().get(0).data().replaceAll("\\s+", " ").trim());
         }
         return stringBuilder.toString();
     }

--- a/bundles/core/src/test/java/com/adobe/cq/email/core/components/internal/css/CssInlinerTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/email/core/components/internal/css/CssInlinerTest.java
@@ -42,7 +42,7 @@ class CssInlinerTest {
         CssInliner sut = new CssInliner();
         String expectedOutput =
                 new String(Files.readAllBytes(Paths.get(ClassLoader.getSystemResource("css/inputStyle.txt").toURI())));
-        assertEquals(expectedOutput, sut.process(getInputHtml()).getInlineStyle());
+        assertEquals(expectedOutput.replaceAll("\\s+", " "), sut.process(getInputHtml()).getInlineStyle().replaceAll("\\s+", " "));
     }
 
     @Test
@@ -66,7 +66,7 @@ class CssInlinerTest {
         CssInliner sut = new CssInliner();
         String expectedOutput =
                 new String(Files.readAllBytes(Paths.get(ClassLoader.getSystemResource("css/output.html").toURI())));
-        assertEquals(expectedOutput.replaceAll("\\s+", ""), sut.process(getInputHtml()).getOutputHtml().replaceAll("\\s+", ""));
+        assertEquals(expectedOutput.replaceAll("\\s+", " "), sut.process(getInputHtml()).getOutputHtml().replaceAll("\\s+", " "));
     }
 
     @Test
@@ -75,7 +75,7 @@ class CssInlinerTest {
         String initialStyleWithCommentedBlock =
                 new String(Files.readAllBytes(Paths.get(ClassLoader.getSystemResource("css/initialStyleWithCommentedBlock.txt").toURI())));
         String outputHtml = sut.process(getInputHtml()).getOutputHtml();
-        assertTrue(outputHtml.replaceAll("\n", " ").replaceAll(" +", " ").contains(initialStyleWithCommentedBlock));
+        assertTrue(outputHtml.replaceAll("\\s+", " ").contains(initialStyleWithCommentedBlock));
     }
 
     private String getInputHtml() throws URISyntaxException, IOException {

--- a/bundles/core/src/test/resources/css/input.html
+++ b/bundles/core/src/test/resources/css/input.html
@@ -68,12 +68,8 @@
 <center>
     <table class="layout" width="640" border="0" cellpadding="0" cellspacing="0" role="presentation">
         <tr>
-            <td width="33.33%" class="layout-column">
-                One Third
-            </td>
-            <td width="66.67%" class="layout-column">
-                Two Third
-            </td>
+            <td width="33.33%" class="layout-column"> One Third </td>
+            <td width="66.67%" class="layout-column"> Two Third </td>
         </tr>
     </table>
 </center>

--- a/bundles/core/src/test/resources/css/output.html
+++ b/bundles/core/src/test/resources/css/output.html
@@ -73,8 +73,8 @@
            style="text-align: center !important; width: 100%;">
         <tbody>
         <tr>
-            <td width="33.33%" class="layout-column" style="background-color: #ccc;"> One Third</td>
-            <td width="66.67%" class="layout-column" style="background-color: #ccc;"> Two Third</td>
+            <td width="33.33%" class="layout-column" style="background-color: #ccc;"> One Third </td>
+            <td width="66.67%" class="layout-column" style="background-color: #ccc;"> Two Third </td>
         </tr>
         </tbody>
     </table>


### PR DESCRIPTION
jUnit test fixes to enable correct handling of Windows newline character

## Description

Changed the way the strings are compared in jUnit test to properly handle Windows and UNIX-like newline characters.

## Related Issue

[https://github.com/adobe/aem-core-email-components/issues/2](url)

## Motivation and Context

The execution of **CssInlinerTest** test class failed on Windows-like machines 

## How Has This Been Tested?

Ran the test on a Windows machine

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
