### PR TITLE
Feature/#26 cf editor personalization

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("12.23.1")
+@Version("12.24.0")
 package com.adobe.cq.email.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/content/src/content/jcr_root/apps/core/email/components/commons/.content.xml
+++ b/content/src/content/jcr_root/apps/core/email/components/commons/.content.xml
@@ -1,0 +1,3 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/content/src/content/jcr_root/apps/core/email/components/commons/editor/clientlibs/cfm/.content.xml
+++ b/content/src/content/jcr_root/apps/core/email/components/commons/editor/clientlibs/cfm/.content.xml
@@ -1,0 +1,5 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    categories="[dam.cfm.authoring.contenteditor.v2]"
+    dependencies="[cq.authoring.editor.plugin.campaign]"/>

--- a/content/src/content/jcr_root/apps/core/email/components/commons/editor/clientlibs/cfm/js.txt
+++ b/content/src/content/jcr_root/apps/core/email/components/commons/editor/clientlibs/cfm/js.txt
@@ -1,0 +1,19 @@
+###############################################################################
+# Copyright 2021 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+#base=js
+
+cfm-editor-personalization.js

--- a/content/src/content/jcr_root/apps/core/email/components/commons/editor/clientlibs/cfm/js/cfm-editor-personalization.js
+++ b/content/src/content/jcr_root/apps/core/email/components/commons/editor/clientlibs/cfm/js/cfm-editor-personalization.js
@@ -1,0 +1,44 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2021 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+
+(function() {
+    "use strict";
+
+    var PERSONALIZATION_PLUGIN_ID = "personalizationplugin",
+        CMD_INSERT_VARIABLE = "insertvariable";
+
+    extendStyledTextEditor();
+
+    function extendStyledTextEditor() {
+        var origFn = Dam.CFM.StyledTextEditor.prototype._start;
+
+        Dam.CFM.StyledTextEditor.prototype._start = function() {
+            addPlugin(this);
+            origFn.call(this);
+        }
+    }
+
+    function addPlugin(editor) {
+        var config = editor.$editable.data("config");
+
+        config.rtePlugins[PERSONALIZATION_PLUGIN_ID] = {
+            features: "*"
+        };
+        config.uiSettings.cui.inline.toolbar.push(PERSONALIZATION_PLUGIN_ID + "#" + CMD_INSERT_VARIABLE);
+        config.uiSettings.cui.multieditorFullscreen.toolbar.push(PERSONALIZATION_PLUGIN_ID + "#" + CMD_INSERT_VARIABLE);
+    }
+
+}());

--- a/content/src/content/jcr_root/apps/core/email/components/commons/editor/clientlibs/cfm/js/cfm-editor-personalization.js
+++ b/content/src/content/jcr_root/apps/core/email/components/commons/editor/clientlibs/cfm/js/cfm-editor-personalization.js
@@ -14,21 +14,21 @@
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 
-(function() {
+(function(ns) {
     "use strict";
 
-    var PERSONALIZATION_PLUGIN_ID = "personalizationplugin",
-        CMD_INSERT_VARIABLE = "insertvariable";
+    var PERSONALIZATION_PLUGIN_ID = "personalizationplugin";
+    var CMD_INSERT_VARIABLE = "insertvariable";
 
     extendStyledTextEditor();
 
     function extendStyledTextEditor() {
-        var origFn = Dam.CFM.StyledTextEditor.prototype._start;
+        var origFn = ns.StyledTextEditor.prototype._start;
 
-        Dam.CFM.StyledTextEditor.prototype._start = function() {
+        ns.StyledTextEditor.prototype._start = function() {
             addPlugin(this);
             origFn.call(this);
-        }
+        };
     }
 
     function addPlugin(editor) {
@@ -41,4 +41,4 @@
         config.uiSettings.cui.multieditorFullscreen.toolbar.push(PERSONALIZATION_PLUGIN_ID + "#" + CMD_INSERT_VARIABLE);
     }
 
-}());
+}(window.Dam.CFM));


### PR DESCRIPTION
Extend CF Editor RTE with personalization

## Description

Added personalization plugin to the Content fragment styled text editor.

## Related Issue

https://github.com/adobe/aem-core-email-components/issues/26

## Motivation and Context

Feature implementation

## How Has This Been Tested?

Local AEM environment, the personalization plugin is added to the CF editor.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [x] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
