### PR TITLE
Style specificity comparison fix when merging styles

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/util/StyleMerger.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/util/StyleMerger.java
@@ -96,7 +96,7 @@ public class StyleMerger {
                 styleProperties.put(propertyName, styleProperty);
                 continue;
             }
-            if (specificityComparison <= 0) {
+            if (specificityComparison > 0) {
                 styleProperties.put(propertyName, styleProperty);
             }
         }

--- a/bundles/core/src/test/java/com/adobe/cq/email/core/components/internal/services/StylesInlinerServiceImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/email/core/components/internal/services/StylesInlinerServiceImplTest.java
@@ -17,12 +17,17 @@ package com.adobe.cq.email.core.components.internal.services;
 
 import java.io.IOException;
 import java.net.URISyntaxException;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.stream.Collectors;
 
 import org.apache.sling.api.resource.ResourceResolver;
 import org.apache.sling.engine.SlingRequestProcessor;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -38,7 +43,6 @@ import static com.adobe.cq.email.core.components.TestFileUtils.INTERNAL_CSS_FILE
 import static com.adobe.cq.email.core.components.TestFileUtils.STYLE_AFTER_PROCESSING_FILE_PATH;
 import static com.adobe.cq.email.core.components.TestFileUtils.compare;
 import static com.adobe.cq.email.core.components.TestFileUtils.getFileContent;
-import static org.junit.jupiter.api.Assertions.assertEquals;
 
 @ExtendWith(MockitoExtension.class)
 class StylesInlinerServiceImplTest {
@@ -67,20 +71,24 @@ class StylesInlinerServiceImplTest {
         Document document = Jsoup.parse(result);
         compare(getFileContent(STYLE_AFTER_PROCESSING_FILE_PATH),
                 document.selectFirst(StylesInlinerConstants.STYLE_TAG).getAllElements().get(0).data());
-        checkElements(document, "body", "font-family: 'Timmana', 'Gill Sans', sans-serif;");
-        checkElements(document, "h1", "font-size: 20px; color: #004488; Margin: 0px;");
-        checkElements(document, "p", "color: #004488; Margin: 0px;");
-        checkElements(document, "img", "border: 10px solid red; -ms-interpolation-mode: bicubic;");
-        checkElements(document, "table", "text-align: center !important; width: 100%;");
-        checkElements(document, "table td", "background-color: #ccc;");
-        checkElements(document, ".blocked", "display: inline-block;");
-        checkElements(document, "h3.example", "border-bottom-width: 12px; border:3px solid green;");
-        checkElements(document, "h3.example2", "border:3px solid green; border-bottom-width:12px;");
+        checkElements(document, "body", Collections.singletonList("font-family: 'Timmana', 'Gill Sans', sans-serif"));
+        checkElements(document, "h1", Arrays.asList("Margin: 0px", "color: #004488", "font-size: 20px"));
+        checkElements(document, "p", Arrays.asList("Margin: 0px", "color: #004488"));
+        checkElements(document, "img", Arrays.asList("-ms-interpolation-mode: bicubic", "border: 10px solid red"));
+        checkElements(document, "table", Arrays.asList("text-align: center !important", "width: 100%"));
+        checkElements(document, "table td", Collections.singletonList("background-color: #ccc"));
+        checkElements(document, ".blocked", Collections.singletonList("display: block"));
+        checkElements(document, ".footer h3", Arrays.asList("border-bottom-width: 12px", "border: 3px solid green", "color: darkgrey"));
+        checkElements(document, "h3.example", Arrays.asList("border-bottom-width: 12px", "border: 3px solid green", "color: darkgrey"));
+        checkElements(document, "h3.example2", Arrays.asList("border-bottom-width: 12px", "border: 3px solid green", "color: darkgrey"));
     }
 
-    private void checkElements(Document document, String cssQuery, String expectedStyle) {
+    private void checkElements(Document document, String cssQuery, List<String> expectedStyles) {
         for (Element element : document.select(cssQuery)) {
-            assertEquals(expectedStyle, element.attr(StylesInlinerConstants.STYLE_ATTRIBUTE));
+            String style = element.attr(StylesInlinerConstants.STYLE_ATTRIBUTE);
+            List<String> currentStyles =
+                    Arrays.stream(style.split(";")).map(String::trim).sorted().collect(Collectors.toList());
+            Assertions.assertEquals(expectedStyles, currentStyles);
         }
     }
 

--- a/bundles/core/src/test/java/com/adobe/cq/email/core/components/util/StyleMergerTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/email/core/components/util/StyleMergerTest.java
@@ -70,7 +70,7 @@ class StyleMergerTest {
         StyleToken elementStyle = create("background-color: #ccc; font-family: 'Timmana', \"Gill Sans\", sans-serif;", true);
         StyleToken styleToken = create("background-color: #aaa; font-size: 20px; color: #004488; Margin: 0px;", false);
         testAllModes(elementStyle, styleToken,
-                "background-color: #ccc; font-size: 20px; color: #004488; Margin: 0px; font-family: 'Timmana', 'Gill Sans', " +
+                "background-color: #aaa; font-size: 20px; color: #004488; Margin: 0px; font-family: 'Timmana', 'Gill Sans', " +
                         "sans-serif;",
                 "background-color: #aaa; font-family: 'Timmana', 'Gill Sans', sans-serif; font-size: 20px; color: #004488; Margin: " +
                         "0px;",
@@ -129,7 +129,7 @@ class StyleMergerTest {
     void samePropertyMultipleTimes() {
         StyleToken elementStyle = create("", true);
         StyleToken styleToken = create("display: block; display: inline-block", false);
-        testAllModes(elementStyle, styleToken, "display: inline-block;", "display: inline-block;", "display: block; display: " +
+        testAllModes(elementStyle, styleToken, "display: block;", "display: inline-block;", "display: block; display: " +
                 "inline-block;");
     }
 

--- a/bundles/core/src/test/resources/testpage/external_css.html
+++ b/bundles/core/src/test/resources/testpage/external_css.html
@@ -32,18 +32,18 @@
 <div class="blocked">
     <h3>Blocked subtitle</h3>
 </div>
-<div>
+<div class="footer">
     <h2>Examples</h2>
-    <h3 class="example" style="border:3px solid green;">Headline with border</h3>
+    <h3 class="example" style="border: 3px solid green;">Headline with border</h3>
     <div>
-        This headline has the following CSS properties set in the style attribute: border:3px solid green;<br/>
+        This headline has the following CSS properties set in the style attribute: border: 3px solid green;<br/>
         In addition, the style element has those definitions: h3.example {border-bottom-width: 12px}.<br/>
         In this case the border should have 3px because the element style attribute has a higher priority.
     </div>
-    <h3 class="example2" style="border-bottom-width:12px;">Headline with wider bottom-border</h3>
+    <h3 class="example2" style="border-bottom-width: 12px;">Headline with wider bottom-border</h3>
     <div>
         This headline has the following CSS properties set in the style attribute: border-bottom-width: 12px<br/>
-        In addition, the style element has those definitions: h3.example2 {border:3px solid green;}.<br/>
+        In addition, the style element has those definitions: h3.example2 {border: 3px solid green;}.<br/>
         In this case the bottom-border should have 12px because the element style attribute has a higher priority.
     </div>
 </div>

--- a/bundles/core/src/test/resources/testpage/internal_and_external_css.html
+++ b/bundles/core/src/test/resources/testpage/internal_and_external_css.html
@@ -11,6 +11,10 @@
             font-size: 20px;
         }
 
+        h3 {
+            color: red;
+        }
+
         h1, p {
             color: #004488;
             Margin: 0px;
@@ -60,12 +64,16 @@
             width: 100%;
         }
 
+        .footer h3 {
+            color: darkgrey;
+        }
+
         h3.example {
             border-bottom-width: 12px;
         }
 
         h3.example2 {
-            border:3px solid green;
+            border: 3px solid green;
         }
 
         h4 {
@@ -102,18 +110,18 @@
 <div class="blocked">
     <h3>Blocked subtitle</h3>
 </div>
-<div>
+<div class="footer">
     <h2>Examples</h2>
-    <h3 class="example" style="border:3px solid green;">Headline with border</h3>
+    <h3 class="example" style="border: 3px solid green;">Headline with border</h3>
     <div>
-        This headline has the following CSS properties set in the style attribute: border:3px solid green;<br/>
+        This headline has the following CSS properties set in the style attribute: border: 3px solid green;<br/>
         In addition, the style element has those definitions: h3.example {border-bottom-width: 12px}.<br/>
         In this case the border should have 3px because the element style attribute has a higher priority.
     </div>
-    <h3 class="example2" style="border-bottom-width:12px;">Headline with wider bottom-border</h3>
+    <h3 class="example2" style="border-bottom-width: 12px;">Headline with wider bottom-border</h3>
     <div>
         This headline has the following CSS properties set in the style attribute: border-bottom-width: 12px<br/>
-        In addition, the style element has those definitions: h3.example2 {border:3px solid green;}.<br/>
+        In addition, the style element has those definitions: h3.example2 {border: 3px solid green;}.<br/>
         In this case the bottom-border should have 12px because the element style attribute has a higher priority.
     </div>
 </div>

--- a/bundles/core/src/test/resources/testpage/internal_css.html
+++ b/bundles/core/src/test/resources/testpage/internal_css.html
@@ -10,6 +10,10 @@
             font-size: 20px;
         }
 
+        h3 {
+            color: red;
+        }
+
         h1, p {
             color: #004488;
             Margin: 0px;
@@ -59,12 +63,16 @@
             width: 100%;
         }
 
+        .footer h3 {
+            color: darkgrey;
+        }
+
         h3.example {
             border-bottom-width: 12px;
         }
 
         h3.example2 {
-            border:3px solid green;
+            border: 3px solid green;
         }
 
         h4 {
@@ -101,18 +109,18 @@
 <div class="blocked">
     <h3>Blocked subtitle</h3>
 </div>
-<div>
+<div class="footer">
     <h2>Examples</h2>
-    <h3 class="example" style="border:3px solid green;">Headline with border</h3>
+    <h3 class="example" style="border: 3px solid green;">Headline with border</h3>
     <div>
-        This headline has the following CSS properties set in the style attribute: border:3px solid green;<br/>
+        This headline has the following CSS properties set in the style attribute: border: 3px solid green;<br/>
         In addition, the style element has those definitions: h3.example {border-bottom-width: 12px}.<br/>
         In this case the border should have 3px because the element style attribute has a higher priority.
     </div>
-    <h3 class="example2" style="border-bottom-width:12px;">Headline with wider bottom-border</h3>
+    <h3 class="example2" style="border-bottom-width: 12px;">Headline with wider bottom-border</h3>
     <div>
         This headline has the following CSS properties set in the style attribute: border-bottom-width: 12px<br/>
-        In addition, the style element has those definitions: h3.example2 {border:3px solid green;}.<br/>
+        In addition, the style element has those definitions: h3.example2 {border: 3px solid green;}.<br/>
         In this case the bottom-border should have 12px because the element style attribute has a higher priority.
     </div>
 </div>

--- a/bundles/core/src/test/resources/testpage/output_without_style.html
+++ b/bundles/core/src/test/resources/testpage/output_without_style.html
@@ -35,12 +35,14 @@
 <div class="blocked">
     <h3>Blocked subtitle</h3>
 </div>
-<div>
+<div class="footer">
     <h2>Examples</h2>
-    <h3 class="example" style="border:3px solid green;">Headline with border</h3>
-    <div> This headline has the following CSS properties set in the style attribute: border:3px solid green; <br> In addition, the style element has those definitions: h3.example {border-bottom-width: 12px}. <br> In this case the border should have 3px because the element style attribute has a higher priority. </div>
-    <h3 class="example2" style="border-bottom-width:12px;">Headline with wider bottom-border</h3>
-    <div> This headline has the following CSS properties set in the style attribute: border-bottom-width: 12px <br> In addition, the style element has those definitions: h3.example2 {border:3px solid green;}. <br> In this case the bottom-border should have 12px because the element style attribute has a higher priority. </div>
+    <h3 class="example" style="border: 3px solid green;">Headline with border</h3>
+    <div> This headline has the following CSS properties set in the style attribute: border: 3px solid green; <br> In addition, the style
+        element has those definitions: h3.example {border-bottom-width: 12px}. <br> In this case the border should have 3px because the element style attribute has a higher priority. </div>
+    <h3 class="example2" style="border-bottom-width: 12px;">Headline with wider bottom-border</h3>
+    <div> This headline has the following CSS properties set in the style attribute: border-bottom-width: 12px <br> In addition, the
+        style element has those definitions: h3.example2 {border: 3px solid green;}. <br> In this case the bottom-border should have 12px because the element style attribute has a higher priority. </div>
 </div>
 </body>
 </html>

--- a/bundles/core/src/test/resources/testpage/style.css
+++ b/bundles/core/src/test/resources/testpage/style.css
@@ -6,6 +6,10 @@
             font-size: 20px;
         }
 
+        h3 {
+            color: red;
+        }
+
         h1, p {
             color: #004488;
             Margin: 0px;
@@ -55,12 +59,16 @@
             width: 100%;
         }
 
+        .footer h3 {
+            color: darkgrey;
+        }
+
         h3.example {
             border-bottom-width: 12px;
         }
 
         h3.example2 {
-        	border:3px solid green;
+        	border: 3px solid green;
         }
 
         h4 {

--- a/content/package-lock.json
+++ b/content/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "com.adobe.cq.core.email.components.content",
-    "version": "0.4.0",
+    "version": "0.5.0-SNAPSHOT",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/content/package.json
+++ b/content/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.adobe.cq.core.email.components.content",
-    "version": "0.4.0",
+    "version": "0.5.0-SNAPSHOT",
     "description": "Adobe Experience Manager Core Email Components Content Package",
     "license": "Apache-2.0",
     "private": false,

--- a/testing/it/it-content/package-lock.json
+++ b/testing/it/it-content/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "com.adobe.cq.core.email.components.it.content",
-  "version": "0.4.0",
+  "version": "0.5.0-SNAPSHOT",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/testing/it/it-content/package.json
+++ b/testing/it/it-content/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.adobe.cq.core.email.components.it.content",
-    "version": "0.4.0",
+    "version": "0.5.0-SNAPSHOT",
     "description": "Adobe Experience Manager Core Email Components IT Content",
     "license": "Apache-2.0",
     "private": false,

--- a/testing/it/ui-js/package-lock.json
+++ b/testing/it/ui-js/package-lock.json
@@ -1,6 +1,6 @@
 {
     "name": "com.adobe.cq.core.email.components.it.ui-js",
-    "version": "0.4.0",
+    "version": "0.5.0-SNAPSHOT",
     "lockfileVersion": 1,
     "requires": true,
     "dependencies": {

--- a/testing/it/ui-js/package.json
+++ b/testing/it/ui-js/package.json
@@ -1,6 +1,6 @@
 {
     "name": "com.adobe.cq.core.email.components.it.ui-js",
-    "version": "0.4.0",
+    "version": "0.5.0-SNAPSHOT",
     "description": "Adobe Experience Manager Core Email Components UI End-to-End Tests",
     "license": "Apache-2.0",
     "private": false,


### PR DESCRIPTION
## Description

Style specificity comparison fix when merging styles

## Related Issue

https://github.com/adobe/aem-core-email-components/issues/63

## Motivation and Context

Bug fixing

## How Has This Been Tested?

- jUnit test
- local AEM instance

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
