### PR TITLE
Style inliner filter

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/filters/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/filters/package-info.java
@@ -13,12 +13,4 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-/**
- * <p>
- * This package defines utility classes exposed by the Adobe Experience Manager Core Email Components Bundle.
- * </p>
- */
-@Version("1.4.1")
-package com.adobe.cq.email.core.components.servlets;
-
-import org.osgi.annotation.versioning.Version;
+package com.adobe.cq.email.core.components.filters;

--- a/bundles/core/src/test/java/com/adobe/cq/email/core/components/filters/StylesInlinerFilterTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/email/core/components/filters/StylesInlinerFilterTest.java
@@ -13,13 +13,14 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-package com.adobe.cq.email.core.components.servlets;
+package com.adobe.cq.email.core.components.filters;
 
 import java.io.IOException;
 import java.io.OutputStream;
 import java.io.PrintWriter;
 import java.lang.annotation.Annotation;
 import java.util.Objects;
+import javax.servlet.FilterChain;
 import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
@@ -36,6 +37,8 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
+import org.mockito.junit.jupiter.MockitoSettings;
+import org.mockito.quality.Strictness;
 
 import com.adobe.cq.email.core.components.config.StylesInlinerContextAwareConfiguration;
 import com.adobe.cq.email.core.components.enumerations.HtmlSanitizingMode;
@@ -50,15 +53,18 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyZeroInteractions;
 import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
-class StylesInlinerServletTest {
+class StylesInlinerFilterTest {
     private static final String INPUT = "TEST_PAGE";
     private static final String OUTPUT_PROCESSING_CSS_SPECIFICITY = "TEST_PAGE_WITH_INLINED_CSS_USING_SPECIFICITY";
     private static final String OUTPUT_IGNORING_CSS_SPECIFICITY = "TEST_PAGE_WITH_INLINED_CSS_WITHOUT_USING_SPECIFICITY";
     private static final String OUTPUT_ALWAYS_APPENDING_CSS_PROPERTIES = "TEST_PAGE_WITH_INLINED_CSS_ALWAYS_APPENDING_CSS_PROPERTIES";
 
+    @Mock
+    FilterChain filterChain;
     @Mock
     RequestResponseFactory requestResponseFactory;
     @Mock
@@ -67,6 +73,8 @@ class StylesInlinerServletTest {
     StylesInlinerService stylesInlinerService;
     @Mock
     Resource resource;
+    @Mock
+    Resource jcrContentNode;
     @Mock
     ConfigurationBuilder configurationBuilder;
     @Mock
@@ -78,11 +86,11 @@ class StylesInlinerServletTest {
     @Mock
     PrintWriter printWriter;
 
-    private StylesInlinerServlet sut;
+    private StylesInlinerFilter sut;
 
     @BeforeEach
     void setUp() throws IOException {
-        this.sut = new StylesInlinerServlet();
+        this.sut = new StylesInlinerFilter();
         this.sut.setRequestResponseFactory(requestResponseFactory);
         this.sut.setRequestProcessor(requestProcessor);
         this.sut.setStylesInlinerService(
@@ -90,6 +98,8 @@ class StylesInlinerServletTest {
         );
         when(request.getResource()).thenReturn(resource);
         when(resource.getPath()).thenReturn("TEST_PATH");
+        when(resource.getChild(eq(StylesInlinerFilter.JCR_CONTENT))).thenReturn(jcrContentNode);
+        when(jcrContentNode.getResourceType()).thenReturn(StylesInlinerFilter.JCR_NODE_EXPECTED_RESOURCE_TYPE);
         HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
         when(requestResponseFactory.createRequest(eq("GET"), eq("TEST_PATH.html"), anyMap())).thenReturn(httpServletRequest);
         doAnswer(i -> {
@@ -113,42 +123,109 @@ class StylesInlinerServletTest {
     }
 
     @Test
+    @MockitoSettings(strictness = Strictness.LENIENT)
+    void noGetRenderedHtmlAttributeInRequest() throws ServletException, IOException {
+        sut.doFilter(request, resp, filterChain);
+        verifyZeroInteractions(filterChain);
+        verify(printWriter).write(eq(OUTPUT_PROCESSING_CSS_SPECIFICITY));
+    }
+
+    @Test
     void noConfig() throws ServletException, IOException {
         when(resource.adaptTo(eq(ConfigurationBuilder.class))).thenReturn(null);
-        sut.doGet(request, resp);
+        sut.doFilter(request, resp, filterChain);
+        verifyZeroInteractions(filterChain);
         verify(printWriter).write(eq(OUTPUT_PROCESSING_CSS_SPECIFICITY));
+    }
+
+    @Test
+    @MockitoSettings(strictness = Strictness.LENIENT)
+    void noConfig_GetRenderedHtmlAttributeInRequest() throws ServletException, IOException {
+        when(resource.adaptTo(eq(ConfigurationBuilder.class))).thenReturn(null);
+        when(request.getAttribute(StylesInlinerFilter.GET_RENDERED_HTML_PARAMETER)).thenReturn(true);
+        sut.doFilter(request, resp, filterChain);
+        verify(filterChain).doFilter(eq(request), eq(resp));
+        verifyZeroInteractions(printWriter);
     }
 
     @Test
     void noStyleMergerMode() throws ServletException, IOException {
         when(resource.adaptTo(eq(ConfigurationBuilder.class))).thenReturn(configurationBuilder);
         when(configurationBuilder.as(StylesInlinerContextAwareConfiguration.class)).thenReturn(create(null));
-        sut.doGet(request, resp);
+        sut.doFilter(request, resp, filterChain);
+        verifyZeroInteractions(filterChain);
         verify(printWriter).write(eq(OUTPUT_PROCESSING_CSS_SPECIFICITY));
+    }
+
+    @Test
+    @MockitoSettings(strictness = Strictness.LENIENT)
+    void noStyleMergerMode_GetRenderedHtmlAttributeInRequest() throws ServletException, IOException {
+        when(resource.adaptTo(eq(ConfigurationBuilder.class))).thenReturn(configurationBuilder);
+        when(request.getAttribute(StylesInlinerFilter.GET_RENDERED_HTML_PARAMETER)).thenReturn(true);
+        when(configurationBuilder.as(StylesInlinerContextAwareConfiguration.class)).thenReturn(create(null));
+        sut.doFilter(request, resp, filterChain);
+        verify(filterChain).doFilter(eq(request), eq(resp));
+        verifyZeroInteractions(printWriter);
     }
 
     @Test
     void processingCssSpecificity() throws Exception {
         when(resource.adaptTo(eq(ConfigurationBuilder.class))).thenReturn(configurationBuilder);
         when(configurationBuilder.as(StylesInlinerContextAwareConfiguration.class)).thenReturn(create(StyleMergerMode.PROCESS_SPECIFICITY));
-        sut.doGet(request, resp);
+        sut.doFilter(request, resp, filterChain);
+        verifyZeroInteractions(filterChain);
         verify(printWriter).write(eq(OUTPUT_PROCESSING_CSS_SPECIFICITY));
+    }
+
+    @Test
+    @MockitoSettings(strictness = Strictness.LENIENT)
+    void processingCssSpecificity_GetRenderedHtmlAttributeInRequest() throws Exception {
+        when(resource.adaptTo(eq(ConfigurationBuilder.class))).thenReturn(configurationBuilder);
+        when(request.getAttribute(StylesInlinerFilter.GET_RENDERED_HTML_PARAMETER)).thenReturn(true);
+        when(configurationBuilder.as(StylesInlinerContextAwareConfiguration.class)).thenReturn(create(StyleMergerMode.PROCESS_SPECIFICITY));
+        sut.doFilter(request, resp, filterChain);
+        verify(filterChain).doFilter(eq(request), eq(resp));
+        verifyZeroInteractions(printWriter);
     }
 
     @Test
     void ignoringCssSpecificity() throws Exception {
         when(resource.adaptTo(eq(ConfigurationBuilder.class))).thenReturn(configurationBuilder);
         when(configurationBuilder.as(StylesInlinerContextAwareConfiguration.class)).thenReturn(create(StyleMergerMode.IGNORE_SPECIFICITY));
-        sut.doGet(request, resp);
+        sut.doFilter(request, resp, filterChain);
+        verifyZeroInteractions(filterChain);
         verify(printWriter).write(eq(OUTPUT_IGNORING_CSS_SPECIFICITY));
+    }
+
+    @Test
+    @MockitoSettings(strictness = Strictness.LENIENT)
+    void ignoringCssSpecificity_GetRenderedHtmlAttributeInRequest() throws Exception {
+        when(resource.adaptTo(eq(ConfigurationBuilder.class))).thenReturn(configurationBuilder);
+        when(request.getAttribute(StylesInlinerFilter.GET_RENDERED_HTML_PARAMETER)).thenReturn(true);
+        when(configurationBuilder.as(StylesInlinerContextAwareConfiguration.class)).thenReturn(create(StyleMergerMode.IGNORE_SPECIFICITY));
+        sut.doFilter(request, resp, filterChain);
+        verify(filterChain).doFilter(eq(request), eq(resp));
+        verifyZeroInteractions(printWriter);
     }
 
     @Test
     void alwaysAppendingCssProperties() throws Exception {
         when(resource.adaptTo(eq(ConfigurationBuilder.class))).thenReturn(configurationBuilder);
         when(configurationBuilder.as(StylesInlinerContextAwareConfiguration.class)).thenReturn(create(StyleMergerMode.ALWAYS_APPEND));
-        sut.doGet(request, resp);
+        sut.doFilter(request, resp, filterChain);
+        verifyZeroInteractions(filterChain);
         verify(printWriter).write(eq(OUTPUT_ALWAYS_APPENDING_CSS_PROPERTIES));
+    }
+
+    @Test
+    @MockitoSettings(strictness = Strictness.LENIENT)
+    void alwaysAppendingCssProperties_GetRenderedHtmlAttributeInRequest() throws Exception {
+        when(resource.adaptTo(eq(ConfigurationBuilder.class))).thenReturn(configurationBuilder);
+        when(request.getAttribute(StylesInlinerFilter.GET_RENDERED_HTML_PARAMETER)).thenReturn(true);
+        when(configurationBuilder.as(StylesInlinerContextAwareConfiguration.class)).thenReturn(create(StyleMergerMode.ALWAYS_APPEND));
+        sut.doFilter(request, resp, filterChain);
+        verify(filterChain).doFilter(eq(request), eq(resp));
+        verifyZeroInteractions(printWriter);
     }
 
     private StylesInlinerContextAwareConfiguration create(StyleMergerMode mode) {

--- a/bundles/core/src/test/java/com/adobe/cq/email/core/components/filters/StylesInlinerFilterTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/email/core/components/filters/StylesInlinerFilterTest.java
@@ -26,6 +26,7 @@ import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.jackrabbit.JcrConstants;
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.SlingHttpServletResponse;
 import org.apache.sling.api.resource.Resource;
@@ -98,7 +99,7 @@ class StylesInlinerFilterTest {
         );
         when(request.getResource()).thenReturn(resource);
         when(resource.getPath()).thenReturn("TEST_PATH");
-        when(resource.getChild(eq(StylesInlinerFilter.JCR_CONTENT))).thenReturn(jcrContentNode);
+        when(resource.getChild(eq(JcrConstants.JCR_CONTENT))).thenReturn(jcrContentNode);
         when(jcrContentNode.getResourceType()).thenReturn(StylesInlinerFilter.RESOURCE_TYPE);
         HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
         when(requestResponseFactory.createRequest(eq("GET"), eq("TEST_PATH.html"), anyMap())).thenReturn(httpServletRequest);

--- a/bundles/core/src/test/java/com/adobe/cq/email/core/components/filters/StylesInlinerFilterTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/email/core/components/filters/StylesInlinerFilterTest.java
@@ -99,7 +99,7 @@ class StylesInlinerFilterTest {
         when(request.getResource()).thenReturn(resource);
         when(resource.getPath()).thenReturn("TEST_PATH");
         when(resource.getChild(eq(StylesInlinerFilter.JCR_CONTENT))).thenReturn(jcrContentNode);
-        when(jcrContentNode.getResourceType()).thenReturn(StylesInlinerFilter.JCR_NODE_EXPECTED_RESOURCE_TYPE);
+        when(jcrContentNode.getResourceType()).thenReturn(StylesInlinerFilter.RESOURCE_TYPE);
         HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
         when(requestResponseFactory.createRequest(eq("GET"), eq("TEST_PATH.html"), anyMap())).thenReturn(httpServletRequest);
         doAnswer(i -> {
@@ -142,7 +142,7 @@ class StylesInlinerFilterTest {
     @MockitoSettings(strictness = Strictness.LENIENT)
     void noConfig_GetRenderedHtmlAttributeInRequest() throws ServletException, IOException {
         when(resource.adaptTo(eq(ConfigurationBuilder.class))).thenReturn(null);
-        when(request.getAttribute(StylesInlinerFilter.GET_RENDERED_HTML_PARAMETER)).thenReturn(true);
+        when(request.getAttribute(StylesInlinerFilter.PROCESSED_ATTRIBUTE)).thenReturn(true);
         sut.doFilter(request, resp, filterChain);
         verify(filterChain).doFilter(eq(request), eq(resp));
         verifyZeroInteractions(printWriter);
@@ -161,7 +161,7 @@ class StylesInlinerFilterTest {
     @MockitoSettings(strictness = Strictness.LENIENT)
     void noStyleMergerMode_GetRenderedHtmlAttributeInRequest() throws ServletException, IOException {
         when(resource.adaptTo(eq(ConfigurationBuilder.class))).thenReturn(configurationBuilder);
-        when(request.getAttribute(StylesInlinerFilter.GET_RENDERED_HTML_PARAMETER)).thenReturn(true);
+        when(request.getAttribute(StylesInlinerFilter.PROCESSED_ATTRIBUTE)).thenReturn(true);
         when(configurationBuilder.as(StylesInlinerContextAwareConfiguration.class)).thenReturn(create(null));
         sut.doFilter(request, resp, filterChain);
         verify(filterChain).doFilter(eq(request), eq(resp));
@@ -181,7 +181,7 @@ class StylesInlinerFilterTest {
     @MockitoSettings(strictness = Strictness.LENIENT)
     void processingCssSpecificity_GetRenderedHtmlAttributeInRequest() throws Exception {
         when(resource.adaptTo(eq(ConfigurationBuilder.class))).thenReturn(configurationBuilder);
-        when(request.getAttribute(StylesInlinerFilter.GET_RENDERED_HTML_PARAMETER)).thenReturn(true);
+        when(request.getAttribute(StylesInlinerFilter.PROCESSED_ATTRIBUTE)).thenReturn(true);
         when(configurationBuilder.as(StylesInlinerContextAwareConfiguration.class)).thenReturn(create(StyleMergerMode.PROCESS_SPECIFICITY));
         sut.doFilter(request, resp, filterChain);
         verify(filterChain).doFilter(eq(request), eq(resp));
@@ -201,7 +201,7 @@ class StylesInlinerFilterTest {
     @MockitoSettings(strictness = Strictness.LENIENT)
     void ignoringCssSpecificity_GetRenderedHtmlAttributeInRequest() throws Exception {
         when(resource.adaptTo(eq(ConfigurationBuilder.class))).thenReturn(configurationBuilder);
-        when(request.getAttribute(StylesInlinerFilter.GET_RENDERED_HTML_PARAMETER)).thenReturn(true);
+        when(request.getAttribute(StylesInlinerFilter.PROCESSED_ATTRIBUTE)).thenReturn(true);
         when(configurationBuilder.as(StylesInlinerContextAwareConfiguration.class)).thenReturn(create(StyleMergerMode.IGNORE_SPECIFICITY));
         sut.doFilter(request, resp, filterChain);
         verify(filterChain).doFilter(eq(request), eq(resp));
@@ -221,7 +221,7 @@ class StylesInlinerFilterTest {
     @MockitoSettings(strictness = Strictness.LENIENT)
     void alwaysAppendingCssProperties_GetRenderedHtmlAttributeInRequest() throws Exception {
         when(resource.adaptTo(eq(ConfigurationBuilder.class))).thenReturn(configurationBuilder);
-        when(request.getAttribute(StylesInlinerFilter.GET_RENDERED_HTML_PARAMETER)).thenReturn(true);
+        when(request.getAttribute(StylesInlinerFilter.PROCESSED_ATTRIBUTE)).thenReturn(true);
         when(configurationBuilder.as(StylesInlinerContextAwareConfiguration.class)).thenReturn(create(StyleMergerMode.ALWAYS_APPEND));
         sut.doFilter(request, resp, filterChain);
         verify(filterChain).doFilter(eq(request), eq(resp));


### PR DESCRIPTION
Style inliner filter

## Description

Style inliner trigger from Servlet filter.

## Related Issue

https://github.com/adobe/aem-core-email-components/issues/75

## Motivation and Context

Style inliner should always be invoked when displaying email pages with wcmmode=disabled option

## How Has This Been Tested?

Local AEM instance

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
