### PR TITLE
Restore StylesInlinerServlet

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/servlets/StylesInlinerServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/servlets/StylesInlinerServlet.java
@@ -1,0 +1,104 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.email.core.components.servlets;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.nio.charset.StandardCharsets;
+import java.util.HashMap;
+import java.util.Map;
+import javax.servlet.Servlet;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.servlets.SlingSafeMethodsServlet;
+import org.apache.sling.engine.SlingRequestProcessor;
+import org.apache.sling.servlets.annotations.SlingServletResourceTypes;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+
+import com.adobe.cq.email.core.components.constants.StylesInlinerConstants;
+import com.adobe.cq.email.core.components.services.StylesInlinerService;
+import com.day.cq.contentsync.handler.util.RequestResponseFactory;
+import com.day.cq.wcm.api.WCMMode;
+
+/**
+ * This servlet will take the AEM page as input, makes the styles inline
+ * and returns the html with inline styles in response.
+ */
+@Component(service = {Servlet.class},
+           immediate = true)
+@SlingServletResourceTypes(
+        resourceTypes = "core/email/components/page",
+        selectors = StylesInlinerConstants.INLINE_STYLES_SELECTOR,
+        extensions = "html")
+public class StylesInlinerServlet extends SlingSafeMethodsServlet {
+
+    @Reference
+    private transient RequestResponseFactory requestResponseFactory;
+
+    @Reference
+    private transient SlingRequestProcessor requestProcessor;
+
+    @Reference
+    private transient StylesInlinerService stylesInlinerService;
+
+    /**
+     * This method gets the AEM page, uses the Styles Inliner Service to convert the AEM page html with css classes
+     * into html with inline styles.
+     *
+     * @param request the sling request
+     * @param resp    the sling response
+     */
+    @Override
+    protected void doGet(final SlingHttpServletRequest request,
+                         final SlingHttpServletResponse resp) throws ServletException, IOException {
+        Map<String, Object> params = new HashMap<>();
+        Resource resource = request.getResource();
+        String pagePath = resource.getPath();
+        HttpServletRequest req = requestResponseFactory.createRequest("GET", pagePath + ".html",
+                params);
+        WCMMode.DISABLED.toRequest(req);
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+        HttpServletResponse response = requestResponseFactory.createResponse(out);
+        response.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        requestProcessor.processRequest(req, response, request.getResourceResolver());
+        String htmlWithInlineStyles =
+                stylesInlinerService.getHtmlWithInlineStyles(request.getResourceResolver(), out.toString(StandardCharsets.UTF_8.name()));
+        resp.setContentType("text/html");
+        resp.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        PrintWriter pw = resp.getWriter();
+        pw.write(htmlWithInlineStyles);
+    }
+
+    void setRequestResponseFactory(RequestResponseFactory requestResponseFactory) {
+        this.requestResponseFactory = requestResponseFactory;
+    }
+
+    void setRequestProcessor(SlingRequestProcessor requestProcessor) {
+        this.requestProcessor = requestProcessor;
+    }
+
+    void setStylesInlinerService(StylesInlinerService stylesInlinerService) {
+        this.stylesInlinerService = stylesInlinerService;
+    }
+
+}

--- a/bundles/core/src/test/java/com/adobe/cq/email/core/components/servlets/StylesInlinerServletTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/email/core/components/servlets/StylesInlinerServletTest.java
@@ -1,0 +1,101 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.email.core.components.servlets;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintWriter;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.commons.io.IOUtils;
+import org.apache.sling.api.SlingHttpServletRequest;
+import org.apache.sling.api.SlingHttpServletResponse;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.api.resource.ResourceResolver;
+import org.apache.sling.caconfig.ConfigurationBuilder;
+import org.apache.sling.engine.SlingRequestProcessor;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import com.adobe.cq.email.core.components.services.StylesInlinerService;
+import com.day.cq.contentsync.handler.util.RequestResponseFactory;
+import com.drew.lang.Charsets;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyMap;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class StylesInlinerServletTest {
+    private static final String INPUT = "TEST_PAGE";
+    private static final String OUTPUT = "TEST_PAGE_WITH_INLINED_CSS";
+
+    @Mock
+    RequestResponseFactory requestResponseFactory;
+    @Mock
+    SlingRequestProcessor requestProcessor;
+    @Mock
+    StylesInlinerService stylesInlinerService;
+    @Mock
+    Resource resource;
+    @Mock
+    SlingHttpServletRequest request;
+    @Mock
+    SlingHttpServletResponse resp;
+    @Mock
+    ResourceResolver resourceResolver;
+    @Mock
+    PrintWriter printWriter;
+
+    private StylesInlinerServlet sut;
+
+    @BeforeEach
+    void setUp() throws IOException {
+        this.sut = new StylesInlinerServlet();
+        this.sut.setRequestResponseFactory(requestResponseFactory);
+        this.sut.setRequestProcessor(requestProcessor);
+        this.sut.setStylesInlinerService(
+                stylesInlinerService
+        );
+        when(request.getResource()).thenReturn(resource);
+        when(resource.getPath()).thenReturn("TEST_PATH");
+        HttpServletRequest httpServletRequest = mock(HttpServletRequest.class);
+        when(requestResponseFactory.createRequest(eq("GET"), eq("TEST_PATH.html"), anyMap())).thenReturn(httpServletRequest);
+        doAnswer(i -> {
+            OutputStream outputStream = (OutputStream) i.getArguments()[0];
+            IOUtils.write(INPUT, outputStream, Charsets.UTF_8);
+            return mock(HttpServletResponse.class);
+        }).when(requestResponseFactory).createResponse(any());
+        when(request.getResourceResolver()).thenReturn(resourceResolver);
+        when(resp.getWriter()).thenReturn(printWriter);
+        when(stylesInlinerService.getHtmlWithInlineStyles(eq(resourceResolver), eq(INPUT))).thenReturn(OUTPUT);
+    }
+
+    @Test
+    void success() throws Exception {
+        sut.doGet(request, resp);
+        verify(printWriter).write(eq(OUTPUT));
+    }
+
+}


### PR DESCRIPTION
Restore StylesInlinerServlet

## Description

Re-enable the possibility to display the page with inlined style, HTML sanitization and wrapper DIVs removed in wcmmode=disabled with "inline-styles" selector.

## Related Issue

https://github.com/adobe/aem-core-email-components/issues/94

## Motivation and Context

Restoring the removed feature

## How Has This Been Tested?

- Local AEM instance
- Rockware DEV AEM instance

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
