### PR TITLE
Link creation fix when using ACC markup in Title and Button component

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/services/AccLinkServiceImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/services/AccLinkServiceImpl.java
@@ -61,17 +61,17 @@ public class AccLinkServiceImpl implements AccLinkService {
             return null;
         }
         try {
+            boolean hasAccMarkup = (url.contains("<%") || url.contains("%>"));
+            if (hasAccMarkup) {
+                return new AccLink(url);
+            }
             String mappedUrl = urlMapperService.getMappedUrl(resourceResolver, request, url);
             if (StringUtils.isEmpty(mappedUrl)) {
                 return null;
             }
-            boolean hasAccMarkup = (url.contains("<%") || url.contains("%>"));
-            mappedUrl = hasAccMarkup ? URLDecoder.decode(mappedUrl) : mappedUrl;
-            if (!hasAccMarkup) {
-                PageManager pageManager = resourceResolver.adaptTo(PageManager.class);
-                if (Objects.nonNull(pageManager) && Objects.nonNull(pageManager.getPage(url))) {
-                    mappedUrl = mappedUrl + ".html";
-                }
+            PageManager pageManager = resourceResolver.adaptTo(PageManager.class);
+            if (Objects.nonNull(pageManager) && Objects.nonNull(pageManager.getPage(url))) {
+                mappedUrl = mappedUrl + ".html";
             }
             return new AccLink<>(mappedUrl);
         } catch (Throwable e) {

--- a/bundles/core/src/test/java/com/adobe/cq/email/core/components/internal/services/AccLinkServiceImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/email/core/components/internal/services/AccLinkServiceImplTest.java
@@ -41,10 +41,8 @@ class AccLinkServiceImplTest {
 
     private static final String URL_WITHOUT_ACC_MARKUP = "/generic/relative/url/without/acc/markup";
     private static final String URL_WITH_ACC_MARKUP = "/generic/relative/url/with/acc/markup/<% recipient.name %>";
-    private static final String ENCODED_URL_WITH_ACC_MARKUP = URLEncoder.encode(URL_WITH_ACC_MARKUP);
+    private static final String ONLY_ACC_MARKUP = "<%=targetData=ctaLink%>";
     private static final String ABSOLUTE_URL_WITHOUT_ACC_MARKUP = "http://server:8080" + URL_WITHOUT_ACC_MARKUP;
-    private static final String ABSOLUTE_URL_WITH_ACC_MARKUP = "http://server:8080" + URL_WITH_ACC_MARKUP;
-    private static final String ENCODED_ABSOLUTE_URL_WITH_ACC_MARKUP = "http://server:8080" + ENCODED_URL_WITH_ACC_MARKUP;
 
 
     @Mock
@@ -134,10 +132,8 @@ class AccLinkServiceImplTest {
     }
 
     @Test
-    void urlWithAccMarkupNotReferringToAPage() {
-        when(urlMapperService.getMappedUrl(eq(resourceResolver), eq(request), eq(URL_WITH_ACC_MARKUP))).thenReturn(
-                ENCODED_ABSOLUTE_URL_WITH_ACC_MARKUP);
-        Link expected = new AccLink<>(ABSOLUTE_URL_WITH_ACC_MARKUP);
+    void urlWithAccMarkup() {
+        Link expected = new AccLink<>(URL_WITH_ACC_MARKUP);
         Link actual = this.sut.create(resourceResolver, request, URL_WITH_ACC_MARKUP);
         assertEquals(expected.isValid(), actual.isValid());
         assertEquals(expected.getURL(), actual.getURL());
@@ -149,4 +145,17 @@ class AccLinkServiceImplTest {
         assertEquals(expected.hashCode(), actual.hashCode());
     }
 
+    @Test
+    void onlyAccMarkup() {
+        Link expected = new AccLink<>(ONLY_ACC_MARKUP);
+        Link actual = this.sut.create(resourceResolver, request, ONLY_ACC_MARKUP);
+        assertEquals(expected.isValid(), actual.isValid());
+        assertEquals(expected.getURL(), actual.getURL());
+        assertEquals(expected.getMappedURL(), actual.getMappedURL());
+        assertEquals(expected.getExternalizedURL(), actual.getExternalizedURL());
+        assertEquals(expected.getHtmlAttributes(), actual.getHtmlAttributes());
+        assertEquals(expected.getReference(), actual.getReference());
+        assertEquals(expected, actual);
+        assertEquals(expected.hashCode(), actual.hashCode());
+    }
 }

--- a/content/package-lock.json
+++ b/content/package-lock.json
@@ -5378,6 +5378,12 @@
             "integrity": "sha1-CXtgK1NCKlIsGvuHkDGDNpQaAR0=",
             "dev": true
         },
+        "oauth-sign": {
+            "version": "0.9.0",
+            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
+            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
+            "dev": true
+        },
         "object-assign": {
             "version": "4.1.1",
             "resolved": "https://registry.npmjs.org/object-assign/-/object-assign-4.1.1.tgz",
@@ -6496,6 +6502,7 @@
                 "isstream": "~0.1.2",
                 "json-stringify-safe": "~5.0.1",
                 "mime-types": "~2.1.19",
+                "oauth-sign": "~0.9.0",
                 "performance-now": "^2.1.0",
                 "qs": "~6.5.2",
                 "safe-buffer": "^5.1.2",
@@ -6544,11 +6551,6 @@
                     "requires": {
                         "mime-db": "1.40.0"
                     }
-                },
-                "oauth-sign": {
-                    "version": "0.9.0-SNAPSHOT",
-                    "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-                    "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ=="
                 },
                 "qs": {
                     "version": "6.5.2",


### PR DESCRIPTION
Link creation fix when using ACC markup in Title and Button component

## Description

Links doesn't have to be externalized when they contain ACC markup

## Related Issue

https://github.com/adobe/aem-core-email-components/issues/129
https://github.com/adobe/aem-core-email-components/issues/131

## Motivation and Context

Bug fix

## How Has This Been Tested?

- Local AEM instance
- jUnit test

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
