### PR TITLE
Segmentation component HTML template change

### DIFF
--- a/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/clientlibs/.content.xml
+++ b/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/clientlibs/.content.xml
@@ -1,4 +1,5 @@
-<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ~ Copyright 2022 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,15 +13,6 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<template data-sly-template.item="${@ item}">
-    <tr>
-        <td class="no-background">${item.openingACCMarkup @ context='html'}</td>
-    </tr>
-    <tr>
-        <sly data-sly-resource="${item.name @ decorationTagName= 'td', cssClassName='no-background'}"></sly>
-    </tr>
-    <tr>
-        <td class="no-background">${item.closingACCMarkup @ context='html'}</td>
-    </tr>
-</template>
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="sling:Folder"/>

--- a/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/clientlibs/site/.content.xml
+++ b/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/clientlibs/site/.content.xml
@@ -1,4 +1,5 @@
-<!--/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+<?xml version="1.0" encoding="UTF-8"?>
+<!--~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
   ~ Copyright 2022 Adobe
   ~
   ~ Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,15 +13,8 @@
   ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
-  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<template data-sly-template.item="${@ item}">
-    <tr>
-        <td class="no-background">${item.openingACCMarkup @ context='html'}</td>
-    </tr>
-    <tr>
-        <sly data-sly-resource="${item.name @ decorationTagName= 'td', cssClassName='no-background'}"></sly>
-    </tr>
-    <tr>
-        <td class="no-background">${item.closingACCMarkup @ context='html'}</td>
-    </tr>
-</template>
+  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~-->
+<jcr:root xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0"
+    jcr:primaryType="cq:ClientLibraryFolder"
+    allowProxy="{Boolean}true"
+    categories="[core.email.components.segmentation.v1.segmentation]"/>

--- a/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/clientlibs/site/css.txt
+++ b/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/clientlibs/site/css.txt
@@ -1,0 +1,19 @@
+###############################################################################
+# Copyright 2022 Adobe
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+###############################################################################
+
+#base=css
+
+segmentation.css

--- a/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/clientlibs/site/css/segmentation.css
+++ b/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/clientlibs/site/css/segmentation.css
@@ -1,0 +1,21 @@
+/*
+ *  Copyright 2022 Adobe
+ *
+ *  Licensed under the Apache License, Version 2.0 (the "License");
+ *  you may not use this file except in compliance with the License.
+ *  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+/* stylelint-disable */
+td.no-background {
+          background-color: transparent;
+        }
+/* stylelint-enable */

--- a/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/item_edit.html
+++ b/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/item_edit.html
@@ -14,13 +14,5 @@
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
 <template data-sly-template.item="${@ item}">
-    <tr>
-        <td class="no-background">${item.openingACCMarkup @ context='html'}</td>
-    </tr>
-    <tr>
-        <sly data-sly-resource="${item.name @ decorationTagName= 'td', cssClassName='no-background'}"></sly>
-    </tr>
-    <tr>
-        <td class="no-background">${item.closingACCMarkup @ context='html'}</td>
-    </tr>
+    <div data-sly-resource="${item.name @ decorationTagName='div'}"></div>
 </template>

--- a/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/segmentation.html
+++ b/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/segmentation.html
@@ -17,6 +17,7 @@
      data-sly-use.templates="core/wcm/components/commons/v1/templates.html"
      data-panelcontainer="${wcmmode.edit && 'tabs'}"
      data-sly-use.itemTemplate="item.html"
+     data-sly-use.itemEditTemplate="item_edit.html"
      id="${tabs.id}"
      class="cmp-tabs"
      data-cmp-is="tabs"
@@ -34,10 +35,11 @@
             class="cmp-tabs__tab${isActive ? ' cmp-tabs__tab--active' : ''}"
             aria-controls="${tab.id}-tabpanel"
             tabindex="${isActive ? '0' : '-1'}"
-            data-cmp-hook-tabs="tab">${tab.title}</li>
+            data-cmp-hook-tabs="tab">${tab.title}
+        </li>
     </ol>
-    <div data-sly-repeat.item="${tabs.items}"
-         data-sly-call="${itemTemplate.item @ item = item}"
+    <div data-sly-test="${wcmmode.edit}" data-sly-repeat.item="${tabs.items}"
+         data-sly-call="${itemEditTemplate.item @ item = item}"
          id="${item.id}-tabpanel"
          role="tabpanel"
          aria-labelledby="${item.id}-tab"
@@ -45,6 +47,17 @@
          class="${wcmmode.edit ? 'cmp-tabs__tabpanel cmp-tabs__tabpanel--active' : ''}"
          data-cmp-hook-tabs="tabpanel"
          data-cmp-data-layer="${item.data.json}"></div>
+    <table data-sly-test="${!wcmmode.edit}">
+        <sly data-sly-repeat.item="${tabs.items}"
+             data-sly-call="${itemTemplate.item @ item = item}"
+             id="${item.id}-tabpanel-noedit"
+             role="tabpanel"
+             aria-labelledby="${item.id}-tab"
+             tabindex="0"
+             class="${wcmmode.edit ? 'cmp-tabs__tabpanel cmp-tabs__tabpanel--active' : ''}"
+             data-cmp-hook-tabs="tabpanel"
+             data-cmp-data-layer="${item.data.json}"></sly>
+    </table>
     <sly data-sly-resource="${resource.path @ resourceType='wcm/foundation/components/parsys/newpar', appendPath='/*', decorationTagName='div', cssClassName='new section aem-Grid-newComponent'}"
          data-sly-test="${(wcmmode.edit || wcmmode.preview) && tabs.items.size < 1}"></sly>
 </div>

--- a/examples/ui.apps/src/content/jcr_root/apps/core-email-components-examples/clientlibs/clientlib-base/.content.xml
+++ b/examples/ui.apps/src/content/jcr_root/apps/core-email-components-examples/clientlibs/clientlib-base/.content.xml
@@ -3,4 +3,4 @@
     jcr:primaryType="cq:ClientLibraryFolder"
     allowProxy="{Boolean}true"
     categories="[cmp-email-examples.base]"
-    embed="[core.email.components.test,core.email.components.container,core.wcm.components.tabs.v1,core.email.components.experiencefragment,core.email.components.teaser,core.email.components.image.v1.image,core.email.components.text.v1.text]"/>
+    embed="[core.email.components.test,core.email.components.container,core.wcm.components.tabs.v1,core.email.components.experiencefragment,core.email.components.teaser,core.email.components.image.v1.image,core.email.components.text.v1.text,core.email.components.segmentation.v1.segmentation]"/>

--- a/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/container/ContainerIT.java
+++ b/testing/it/e2e-selenium/src/test/java/com/adobe/cq/wcm/core/components/it/seljup/tests/container/ContainerIT.java
@@ -74,10 +74,11 @@ public class ContainerIT extends AuthorBaseUITest {
         setValueInCombobox(webDriver, act, "3-3");
         viewAsPublished(webDriver);
         List<WebElement> elements = webDriver.findElements(By.cssSelector("[class='layout-column grid-3']"));
-        assertEquals(2, elements.size());
-        WebElement firstColumn = elements.get(0);
+        assertEquals(4, elements.size());
+        // skipping first element (outer layout)
+        WebElement firstColumn = elements.get(1);
         assertTrue(firstColumn.isDisplayed());
-        WebElement secondColumn = elements.get(1);
+        WebElement secondColumn = elements.get(2);
         assertTrue(secondColumn.isDisplayed());
         assertEquals(firstColumn.getSize().getWidth(), secondColumn.getSize().getWidth(), 1);
     }


### PR DESCRIPTION
Segmentation component HTML template change

## Description

Segmentation component now renders (in wcmmode disabled) as a table.

## Related Issue

https://github.com/adobe/aem-core-email-components/issues/157

## Motivation and Context

Feature implementation

## How Has This Been Tested?

- Local AEM instance
- Selenium test

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
