### PR TITLE
Style Inliner - Incorrect encoding when adding <style> attribute

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/services/StylesInlinerServiceImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/services/StylesInlinerServiceImpl.java
@@ -18,6 +18,7 @@ package com.adobe.cq.email.core.components.internal.services;
 import java.io.ByteArrayInputStream;
 import java.lang.annotation.Annotation;
 import java.util.ArrayList;
+import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
@@ -127,14 +128,16 @@ public class StylesInlinerServiceImpl implements StylesInlinerService {
                     populateStylesToBeApplied(styleToken, doc, styleTokens, unInlinableStyleTokens);
                 }
             }
+            String stylePlaceholder = "!!!STYLE_PLACEHOLDER_" + new Date().getTime() + "!!!";
             HtmlSanitizer.sanitizeDocument(doc);
             applyStyles(doc, styleTokens);
-            writeStyleTag(doc, styleSb, unInlinableStyleTokens);
+            processStyle(doc, styleSb, stylePlaceholder, unInlinableStyleTokens);
             WrapperDivRemover.removeWrapperDivs(doc, stylesInlinerConfig.wrapperDivClassesToBeRemoved());
             String outerHtml = doc.outerHtml();
             if (StringUtils.isEmpty(outerHtml)) {
                 return outerHtml;
             }
+            outerHtml = outerHtml.replace(stylePlaceholder, styleSb.toString());
             return outerHtml.replaceAll("\n", "").replaceAll("\r", "").replaceAll("\t", "");
         } catch (Throwable e) {
             throw new StylesInlinerException("An error occurred during execution: " + e.getMessage(), e);
@@ -220,7 +223,7 @@ public class StylesInlinerServiceImpl implements StylesInlinerService {
         }
     }
 
-    private void writeStyleTag(Document doc, StringBuilder styleSb, List<StyleToken> unusedStyleTokens) {
+    private void processStyle(Document doc, StringBuilder styleSb, String stylePlaceholder, List<StyleToken> unusedStyleTokens) {
         if (Objects.isNull(unusedStyleTokens) || unusedStyleTokens.isEmpty()) {
             return;
         }
@@ -230,7 +233,7 @@ public class StylesInlinerServiceImpl implements StylesInlinerService {
         for (StyleToken styleToken : unusedStyleTokens) {
             styleSb.append(StyleTokenFactory.toCss(styleToken)).append("\n\t\t");
         }
-        style.html("\n\t\t" + styleSb);
+        style.text(stylePlaceholder);
     }
 
     void setRequestResponseFactory(RequestResponseFactory requestResponseFactory) {

--- a/bundles/core/src/test/java/com/adobe/cq/email/core/components/TestFileUtils.java
+++ b/bundles/core/src/test/java/com/adobe/cq/email/core/components/TestFileUtils.java
@@ -26,12 +26,14 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 public class TestFileUtils {
     public final static String INTERNAL_CSS_HTML_FILE_PATH = "testpage/internal_css.html";
+    public final static String INTERNAL_CSS_WITH_IMMEDIATE_CHILDREN_HTML_FILE_PATH = "testpage/internal_css_with_immediate_children.html";
     public final static String INTERNAL_CSS_JSON_FILE_PATH = "testpage/internal_css.json";
     public final static String EXTERNAL_CSS_FILE_PATH = "testpage/external_css.html";
     public final static String INTERNAL_AND_EXTERNAL_CSS_FILE_PATH = "testpage/internal_and_external_css.html";
     public final static String OUTPUT_FILE_PATH = "testpage/output_without_style.html";
     public final static String STYLE_FILE_PATH = "testpage/style.css";
     public final static String STYLE_AFTER_PROCESSING_FILE_PATH = "testpage/unused_style.css";
+    public final static String STYLE_AFTER_PROCESSING_WITH_IMMEDIATE_CHILDREN_FILE_PATH = "testpage/unused_style_with_immediate_children.css";
     public final static String TO_BE_SANITIZED_FILE_PATH = "testpage/to_be_sanitized.html";
     public final static String WITHOUT_SCRIPTS_FILE_PATH = "testpage/without_scripts.html";
     public final static String SANITIZED_FILE_PATH = "testpage/sanitized.html";

--- a/bundles/core/src/test/java/com/adobe/cq/email/core/components/internal/services/StylesInlinerServiceImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/email/core/components/internal/services/StylesInlinerServiceImplTest.java
@@ -22,6 +22,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.json.Json;
 import javax.json.JsonReader;
@@ -31,6 +32,7 @@ import org.apache.sling.engine.SlingRequestProcessor;
 import org.jsoup.Jsoup;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.jsoup.select.Elements;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -43,7 +45,9 @@ import com.day.cq.contentsync.handler.util.RequestResponseFactory;
 
 import static com.adobe.cq.email.core.components.TestFileUtils.INTERNAL_CSS_HTML_FILE_PATH;
 import static com.adobe.cq.email.core.components.TestFileUtils.INTERNAL_CSS_JSON_FILE_PATH;
+import static com.adobe.cq.email.core.components.TestFileUtils.INTERNAL_CSS_WITH_IMMEDIATE_CHILDREN_HTML_FILE_PATH;
 import static com.adobe.cq.email.core.components.TestFileUtils.STYLE_AFTER_PROCESSING_FILE_PATH;
+import static com.adobe.cq.email.core.components.TestFileUtils.STYLE_AFTER_PROCESSING_WITH_IMMEDIATE_CHILDREN_FILE_PATH;
 import static com.adobe.cq.email.core.components.TestFileUtils.compareRemovingNewLinesAndTabs;
 import static com.adobe.cq.email.core.components.TestFileUtils.getFileContent;
 
@@ -74,16 +78,19 @@ class StylesInlinerServiceImplTest {
         Document document = Jsoup.parse(result);
         compareRemovingNewLinesAndTabs(getFileContent(STYLE_AFTER_PROCESSING_FILE_PATH),
                 document.selectFirst(StylesInlinerConstants.STYLE_TAG).getAllElements().get(0).data());
-        checkElements(document, "body", Collections.singletonList("font-family: 'Timmana', 'Gill Sans', sans-serif"));
-        checkElements(document, "h1", Arrays.asList("Margin: 0px", "color: #004488", "font-size: 20px"));
-        checkElements(document, "p", Arrays.asList("Margin: 0px", "color: #004488"));
-        checkElements(document, "img", Arrays.asList("-ms-interpolation-mode: bicubic", "border: 10px solid red"));
-        checkElements(document, "table", Arrays.asList("text-align: center !important", "width: 100%"));
-        checkElements(document, "table td", Collections.singletonList("background-color: #ccc"));
-        checkElements(document, ".blocked", Collections.singletonList("display: block"));
-        checkElements(document, ".footer h3", Arrays.asList("border-bottom-width: 12px", "border: 3px solid green", "color: darkgrey"));
-        checkElements(document, "h3.example", Arrays.asList("border-bottom-width: 12px", "border: 3px solid green", "color: darkgrey"));
-        checkElements(document, "h3.example2", Arrays.asList("border-bottom-width: 12px", "border: 3px solid green", "color: darkgrey"));
+        checkElements(document, "body", Collections.singletonList("font-family: 'Timmana', 'Gill Sans', sans-serif"), Optional.empty());
+        checkElements(document, "h1", Arrays.asList("Margin: 0px", "color: #004488", "font-size: 20px"), Optional.empty());
+        checkElements(document, "p", Arrays.asList("Margin: 0px", "color: #004488"), Optional.empty());
+        checkElements(document, "img", Arrays.asList("-ms-interpolation-mode: bicubic", "border: 10px solid red"), Optional.empty());
+        checkElements(document, "table", Arrays.asList("text-align: center !important", "width: 100%"), Optional.empty());
+        checkElements(document, "table td", Collections.singletonList("background-color: #ccc"), Optional.empty());
+        checkElements(document, ".blocked", Collections.singletonList("display: block"), Optional.empty());
+        checkElements(document, ".footer h3", Arrays.asList("border-bottom-width: 12px", "border: 3px solid green", "color: darkgrey"),
+                Optional.empty());
+        checkElements(document, "h3.example", Arrays.asList("border-bottom-width: 12px", "border: 3px solid green", "color: darkgrey"),
+                Optional.empty());
+        checkElements(document, "h3.example2", Arrays.asList("border-bottom-width: 12px", "border: 3px solid green", "color: darkgrey"),
+                Optional.empty());
     }
 
     @Test
@@ -96,20 +103,55 @@ class StylesInlinerServiceImplTest {
         Document document = Jsoup.parse(html);
         compareRemovingNewLinesAndTabs(getFileContent(STYLE_AFTER_PROCESSING_FILE_PATH),
                 document.selectFirst(StylesInlinerConstants.STYLE_TAG).getAllElements().get(0).data());
-        checkElements(document, "body", Collections.singletonList("font-family: 'Timmana', 'Gill Sans', sans-serif"));
-        checkElements(document, "h1", Arrays.asList("Margin: 0px", "color: #004488", "font-size: 20px"));
-        checkElements(document, "p", Arrays.asList("Margin: 0px", "color: #004488"));
-        checkElements(document, "img", Arrays.asList("-ms-interpolation-mode: bicubic", "border: 10px solid red"));
-        checkElements(document, "table", Arrays.asList("text-align: center !important", "width: 100%"));
-        checkElements(document, "table td", Collections.singletonList("background-color: #ccc"));
-        checkElements(document, ".blocked", Collections.singletonList("display: block"));
-        checkElements(document, ".footer h3", Arrays.asList("border-bottom-width: 12px", "border: 3px solid green", "color: darkgrey"));
-        checkElements(document, "h3.example", Arrays.asList("border-bottom-width: 12px", "border: 3px solid green", "color: darkgrey"));
-        checkElements(document, "h3.example2", Arrays.asList("border-bottom-width: 12px", "border: 3px solid green", "color: darkgrey"));
+        checkElements(document, "body", Collections.singletonList("font-family: 'Timmana', 'Gill Sans', sans-serif"), Optional.empty());
+        checkElements(document, "h1", Arrays.asList("Margin: 0px", "color: #004488", "font-size: 20px"), Optional.empty());
+        checkElements(document, "p", Arrays.asList("Margin: 0px", "color: #004488"), Optional.empty());
+        checkElements(document, "img", Arrays.asList("-ms-interpolation-mode: bicubic", "border: 10px solid red"), Optional.empty());
+        checkElements(document, "table", Arrays.asList("text-align: center !important", "width: 100%"), Optional.empty());
+        checkElements(document, "table td", Collections.singletonList("background-color: #ccc"), Optional.empty());
+        checkElements(document, ".blocked", Collections.singletonList("display: block"), Optional.empty());
+        checkElements(document, ".footer h3", Arrays.asList("border-bottom-width: 12px", "border: 3px solid green", "color: darkgrey"),
+                Optional.empty());
+        checkElements(document, "h3.example", Arrays.asList("border-bottom-width: 12px", "border: 3px solid green", "color: darkgrey"),
+                Optional.empty());
+        checkElements(document, "h3.example2", Arrays.asList("border-bottom-width: 12px", "border: 3px solid green", "color: darkgrey"),
+                Optional.empty());
     }
 
-    private void checkElements(Document document, String cssQuery, List<String> expectedStyles) {
-        for (Element element : document.select(cssQuery)) {
+    @Test
+    void success_CssWithImmediateChildren() throws URISyntaxException, IOException {
+        String result =
+                sut.getHtmlWithInlineStyles(resourceResolver, getFileContent(INTERNAL_CSS_WITH_IMMEDIATE_CHILDREN_HTML_FILE_PATH));
+        Document document = Jsoup.parse(result);
+        compareRemovingNewLinesAndTabs(getFileContent(STYLE_AFTER_PROCESSING_WITH_IMMEDIATE_CHILDREN_FILE_PATH),
+                document.selectFirst(StylesInlinerConstants.STYLE_TAG).getAllElements().get(0).data());
+        checkElements(document, "body", Collections.singletonList(""), Optional.empty());
+        checkElements(document, "h1", Arrays.asList("Margin: 0px", "color: #004488", "font-size: 20px"), Optional.empty());
+        checkElements(document, "p", Arrays.asList("Margin: 0px", "color: #004488"), Optional.empty());
+        checkElements(document, "img", Arrays.asList("-ms-interpolation-mode: bicubic", "border: 10px solid red"), Optional.empty());
+        checkElements(document, "table",
+                Arrays.asList("text-align: center !important", "width: 100%"),
+                Optional.of(0));
+        checkElements(document, "table",
+                Arrays.asList("font-family: 'Timmana', 'Gill Sans', sans-serif", "text-align: center !important", "width: 100%"),
+                Optional.of(1));
+        checkElements(document, "table td", Collections.singletonList("background-color: #ccc"), Optional.empty());
+        checkElements(document, ".blocked", Collections.singletonList("display: block"), Optional.empty());
+        checkElements(document, ".footer h3", Arrays.asList("border-bottom-width: 12px", "border: 3px solid green", "color: darkgrey"),
+                Optional.empty());
+        checkElements(document, "h3.example", Arrays.asList("border-bottom-width: 12px", "border: 3px solid green", "color: darkgrey"),
+                Optional.empty());
+        checkElements(document, "h3.example2", Arrays.asList("border-bottom-width: 12px", "border: 3px solid green", "color: darkgrey"),
+                Optional.empty());
+    }
+
+    private void checkElements(Document document, String cssQuery, List<String> expectedStyles, Optional<Integer> index) {
+        Elements elements = document.select(cssQuery);
+        for (int i = 0; i < elements.size(); i++) {
+            Element element = elements.get(i);
+            if (index.isPresent() && index.get() != i) {
+                continue;
+            }
             String style = element.attr(StylesInlinerConstants.STYLE_ATTRIBUTE);
             List<String> currentStyles =
                     Arrays.stream(style.split(";")).map(String::trim).sorted().collect(Collectors.toList());

--- a/bundles/core/src/test/resources/testpage/internal_css_with_immediate_children.html
+++ b/bundles/core/src/test/resources/testpage/internal_css_with_immediate_children.html
@@ -1,0 +1,136 @@
+<html>
+<head>
+    <title>Hello</title>
+    <style type="text/css">
+        body > center > table {
+            font-family: 'Timmana', "Gill Sans", sans-serif;
+        }
+
+        h1 {
+            font-size: 20px;
+        }
+
+        h3 {
+            color: red;
+        }
+
+        h1, p {
+            color: #004488;
+            Margin: 0px;
+        }
+
+        p::before,
+        p::after {
+            content: '"';
+        }
+
+        img {
+            -ms-interpolation-mode: bicubic;
+        }
+
+        table {
+            text-align: center !important;
+            width: 100%;
+        }
+
+        table td {
+            background-color: #ccc;
+        }
+
+        @media screen and (max-width: 640px) {
+            table.layout {
+                width: 100% !important;
+            }
+        }
+
+        @media screen and (max-width: 480px) {
+            td.layout-column {
+                display: block !important;
+                width: 100% !important;
+            }
+        }
+
+        @media (max-width: 320px) {
+            body > center > table {
+                width: 320px;
+            }
+        }
+
+        .border {
+            border: 10px solid red;
+        }
+
+        .blocked {
+            display: block;
+            display: inline-block;
+        }
+
+        .ExternalClass {
+            width: 100%;
+        }
+
+        .footer h3 {
+            color: darkgrey;
+        }
+
+        h3.example {
+            border-bottom-width: 12px;
+        }
+
+        h3.example2 {
+            border: 3px solid green;
+        }
+
+        h4 {
+            font-weight: bold;
+        }
+
+    </style>
+    <!--[if mso]>
+    <style>.hide-mso {
+        display: none;
+    }
+    </style><![endif]-->
+</head>
+<body>
+<h1>Hello</h1>
+<p>World</p>
+<img src="aempic.png" height="128" width="128" class="border"/>
+<table class="layout">
+    <tr>
+        <td class="layout-column">one</td>
+        <td class="layout-column">two</td>
+    </tr>
+    <tr>
+        <td class="layout-column">1</td>
+        <td class="layout-column">2</td>
+    </tr>
+</table>
+<center>
+    <table class="layout" width="640" border="0" cellpadding="0" cellspacing="0" role="presentation">
+        <tr>
+            <td width="33.33%" class="layout-column"> One Third</td>
+            <td width="66.67%" class="layout-column"> Two Third</td>
+        </tr>
+    </table>
+</center>
+<div class="blocked">
+    <h3>Blocked subtitle</h3>
+</div>
+<div class="footer">
+    <h2>Examples</h2>
+    <h3 class="example" style="border: 3px solid green;">Headline with border</h3>
+    <div>
+        This headline has the following CSS properties set in the style attribute: border: 3px solid green;<br/>
+        In addition, the style element has those definitions: h3.example {border-bottom-width: 12px}.<br/>
+        In this case the border should have 3px because the element style attribute has a higher priority.
+    </div>
+    <h3 class="example2" style="border-bottom-width: 12px;">Headline with wider bottom-border</h3>
+    <div>
+        This headline has the following CSS properties set in the style attribute: border-bottom-width: 12px<br/>
+        In addition, the style element has those definitions: h3.example2 {border: 3px solid green;}.<br/>
+        In this case the bottom-border should have 12px because the element style attribute has a higher priority.
+    </div>
+</div>
+</body>
+</html>

--- a/bundles/core/src/test/resources/testpage/unused_style_with_immediate_children.css
+++ b/bundles/core/src/test/resources/testpage/unused_style_with_immediate_children.css
@@ -1,0 +1,5 @@
+p::before, p::after {content: '"';}
+@media screen and (max-width: 640px) {table.layout { width: 100% !important; }}
+@media screen and (max-width: 480px) {td.layout-column { display: block !important; width: 100% !important; }}
+@media (max-width: 320px) {body > center > table { width: 320px; }}
+.ExternalClass {width: 100%;}h4 {font-weight: bold;}


### PR DESCRIPTION
Style Inliner - Incorrect encoding when adding <style> attribute

## Description

CSS stylesheet was encoded while returning the HTML page with inline styles

## Related Issue

https://github.com/adobe/aem-core-email-components/issues/168

## Motivation and Context

Bug fixing

## How Has This Been Tested?

- Local AEM instance
- jUnit test

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
