### PR TITLE
Segmentation item HTML template fix

### DIFF
--- a/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/segmentation.html
+++ b/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/segmentation.html
@@ -38,7 +38,7 @@
             data-cmp-hook-tabs="tab">${tab.title}
         </li>
     </ol>
-    <div data-sly-test="${wcmmode.edit}" data-sly-repeat.item="${tabs.items}"
+    <div data-sly-test="${wcmmode.edit || wcmmode.preview}" data-sly-repeat.item="${tabs.items}"
          data-sly-call="${itemEditTemplate.item @ item = item}"
          id="${item.id}-tabpanel"
          role="tabpanel"
@@ -47,7 +47,7 @@
          class="${!wcmmode.disabled ? 'cmp-tabs__tabpanel cmp-tabs__tabpanel--active' : ''}"
          data-cmp-hook-tabs="tabpanel"
          data-cmp-data-layer="${item.data.json}"></div>
-    <table data-sly-test="${!wcmmode.edit}">
+    <table data-sly-test="${wcmmode.disabled}">
         <sly data-sly-repeat.item="${tabs.items}"
              data-sly-call="${itemTemplate.item @ item = item}"
              id="${item.id}-tabpanel-noedit"


### PR DESCRIPTION
Segmentation item HTML template fix

## Description

In preview mode the segmentation component gets displayed with tabs heading and with ACC markup.

## Related Issue

https://github.com/adobe/aem-core-email-components/issues/173

## Motivation and Context

Bug fix

## How Has This Been Tested?

Local AEM instance

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
