### PR TITLE
Wrapper DIV remover performance fix

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/services/StylesInlinerServiceImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/services/StylesInlinerServiceImpl.java
@@ -227,10 +227,10 @@ public class StylesInlinerServiceImpl implements StylesInlinerService {
                 StyleToken mergedStyleToken = StyleMerger.merge(currentElement, styleToken);
                 String style = StyleTokenFactory.getInlinablePropertiesIgnoringNesting(mergedStyleToken);
                 if (StringUtils.isNotEmpty(style)) {
+                    String tagName = elementToApply.tagName();
                     elementToApply.attr(StylesInlinerConstants.STYLE_ATTRIBUTE, style);
                     HtmlAttributeInliner.process(elementToApply, mergedStyleToken,
-                            htmlInlinerConfigurationList.stream().filter(c -> elementSelector.equals(c.getElementType())).findFirst()
-                                    .orElse(null));
+                            htmlInlinerConfigurationList.stream().filter(c -> tagName.equals(c.getElementType())).findFirst().orElse(null));
                 }
             }
         }

--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/util/WrapperDivRemover.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/util/WrapperDivRemover.java
@@ -17,6 +17,7 @@ package com.adobe.cq.email.core.components.util;
 
 import java.util.Objects;
 
+import org.apache.commons.lang3.StringUtils;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
 import org.jsoup.select.Elements;
@@ -57,20 +58,31 @@ public class WrapperDivRemover {
             return;
         }
         for (Element child : children) {
-            for (String wrapperDivClassToBeRemoved : wrapperDivClassesToBeRemoved) {
-                if (child.tagName().equalsIgnoreCase("div") && child.is("." + wrapperDivClassToBeRemoved)) {
-                    Elements removedDivChildren = child.children();
-                    int index = child.siblingIndex();
-                    if (Objects.nonNull(child.parentNode())) {
-                        child.remove();
-                        parent.insertChildren(index, removedDivChildren);
-                        removeWrapperDivs(parent, parent.children(), wrapperDivClassesToBeRemoved);
-                    }
-                } else {
-                    removeWrapperDivs(child, child.children(), wrapperDivClassesToBeRemoved);
+            if (child.tagName().equalsIgnoreCase("div") && containsClassToBeRemoved(child, wrapperDivClassesToBeRemoved)) {
+                Elements removedDivChildren = child.children();
+                int index = child.siblingIndex();
+                if (Objects.nonNull(child.parentNode())) {
+                    child.remove();
+                    parent.insertChildren(index, removedDivChildren);
+                    removeWrapperDivs(parent, parent.children(), wrapperDivClassesToBeRemoved);
                 }
+            } else {
+                removeWrapperDivs(child, child.children(), wrapperDivClassesToBeRemoved);
             }
         }
+    }
+
+    private static boolean containsClassToBeRemoved(Element element, String[] wrapperDivClassesToBeRemoved) {
+        String elementClassAttribute = element.attr("class");
+        if (StringUtils.isEmpty(elementClassAttribute)) {
+            return false;
+        }
+        for (String wrapperDivClassToBeRemoved : wrapperDivClassesToBeRemoved) {
+            if (elementClassAttribute.contains(wrapperDivClassToBeRemoved)) {
+                return true;
+            }
+        }
+        return false;
     }
 
 }

--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/util/WrapperDivRemover.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/util/WrapperDivRemover.java
@@ -59,13 +59,8 @@ public class WrapperDivRemover {
         }
         for (Element child : children) {
             if (child.tagName().equalsIgnoreCase("div") && containsClassToBeRemoved(child, wrapperDivClassesToBeRemoved)) {
-                Elements removedDivChildren = child.children();
-                int index = child.siblingIndex();
-                if (Objects.nonNull(child.parentNode())) {
-                    child.remove();
-                    parent.insertChildren(index, removedDivChildren);
-                    removeWrapperDivs(parent, parent.children(), wrapperDivClassesToBeRemoved);
-                }
+                child.unwrap();
+                removeWrapperDivs(parent, parent.children(), wrapperDivClassesToBeRemoved);
             } else {
                 removeWrapperDivs(child, child.children(), wrapperDivClassesToBeRemoved);
             }

--- a/bundles/core/src/test/java/com/adobe/cq/email/core/components/util/WrapperDivRemoverTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/email/core/components/util/WrapperDivRemoverTest.java
@@ -50,7 +50,7 @@ class WrapperDivRemoverTest {
     void removedDivs() throws URISyntaxException, IOException {
         String html = TestFileUtils.getFileContent(TestFileUtils.WRAPPER_DIV_REMOVAL_INPUT_FILE_PATH);
         Document document = Jsoup.parse(html);
-        WrapperDivRemover.removeWrapperDivs(document, new String[]{"aem-Grid", "aem-GridColumn", "cmp-title__text"});
+        WrapperDivRemover.removeWrapperDivs(document, new String[]{"responsivegrid", "aem-Grid", "aem-GridColumn", "cmp-title__text"});
         compareRemovingNewLinesAndTabs(TestFileUtils.getFileContent(TestFileUtils.WRAPPER_DIV_REMOVAL_OUTPUT_DIVS_REMOVED_FILE_PATH),
                 document.outerHtml());
     }

--- a/bundles/core/src/test/resources/wrapper-div-removal/output_divs_removed.html
+++ b/bundles/core/src/test/resources/wrapper-div-removal/output_divs_removed.html
@@ -10,7 +10,6 @@
           href="http://192.168.1.50:4503/content/campaigns/core-email-components-examples/master/core-email-spender/test.html">
 </head>
 <body class="page basicpage" id="page-5ca4668d10">
-<div class="root responsivegrid">
     <div id="title-10d30dc081" class="cmp-title">
         <h1 class="cmp-title__text">AAAAA</h1>
     </div>
@@ -25,7 +24,6 @@
     <button type="button" id="button-3adfc951ee" class="cmp-button">
         <span class="cmp-button__text">Title</span>
     </button>
-</div>
 <script async src="/etc.clientlibs/core/wcm/components/commons/site/clientlibs/container.js"></script>
 <script async src="/etc.clientlibs/core-email-components-examples/clientlibs/clientlib-base.js"></script>
 <div class="cloudservice campaign"></div>


### PR DESCRIPTION
Wrapper DIV remover performance fix

## Description

The performance of Wrapper DIV remover decreases significantly when the size of the DIV classes to be removed grows, eventually halting execution.

## Related Issue

https://github.com/adobe/aem-core-email-components/issues/180

## Motivation and Context

Bug fixing

## How Has This Been Tested?

Local AEM instance

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [] I have added tests to cover my changes.
- [X] All new and existing tests passed.
