### PR TITLE
Multiple HtmlInlinerConfiguration application for the same HTML element

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/services/StylesInlinerServiceImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/services/StylesInlinerServiceImpl.java
@@ -22,6 +22,7 @@ import java.util.Date;
 import java.util.List;
 import java.util.Objects;
 import java.util.Optional;
+import java.util.stream.Collectors;
 import javax.json.Json;
 import javax.json.JsonObject;
 import javax.json.JsonObjectBuilder;
@@ -230,7 +231,8 @@ public class StylesInlinerServiceImpl implements StylesInlinerService {
                     String tagName = elementToApply.tagName();
                     elementToApply.attr(StylesInlinerConstants.STYLE_ATTRIBUTE, style);
                     HtmlAttributeInliner.process(elementToApply, mergedStyleToken,
-                            htmlInlinerConfigurationList.stream().filter(c -> tagName.equals(c.getElementType())).findFirst().orElse(null));
+                            htmlInlinerConfigurationList.stream().filter(c -> tagName.equals(c.getElementType()))
+                                    .collect(Collectors.toList()));
                 }
             }
         }

--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/util/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/util/package-info.java
@@ -18,7 +18,7 @@
  *      This package defines utility classes exposed by the Adobe Experience Manager Core Email Components Bundle.
  * </p>
  */
-@Version("4.0.0")
+@Version("5.0.0")
 package com.adobe.cq.email.core.components.util;
 
 import org.osgi.annotation.versioning.Version;


### PR DESCRIPTION
Multiple HtmlInlinerConfiguration application for the same HTML element

## Description

If there are multiple HtmlInlinerConfigurations that refers to the same HTML element, all of them should be applied

## Related Issue

https://github.com/adobe/aem-core-email-components/issues/184

## Motivation and Context

Bug fix

## How Has This Been Tested?

Local AEM instance

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [Z] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
