### PR TITLE
CSS parsing enhancements

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/util/StyleTokenizer.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/util/StyleTokenizer.java
@@ -21,6 +21,7 @@ import java.util.Objects;
 import java.util.StringTokenizer;
 
 import org.apache.commons.lang3.StringUtils;
+import org.jetbrains.annotations.NotNull;
 
 import com.adobe.cq.email.core.components.constants.StylesInlinerConstants;
 import com.adobe.cq.email.core.components.pojo.StyleToken;
@@ -40,7 +41,7 @@ public class StyleTokenizer {
      * @param css the CSS stylesheet
      * @return a {@link List} of {@link StyleToken}
      */
-    public static List<StyleToken> tokenize(String css) {
+    public static @NotNull List<StyleToken> tokenize(String css) {
         List<StyleToken> result = new ArrayList<>();
         if (StringUtils.isEmpty(css)) {
             return result;
@@ -61,9 +62,13 @@ public class StyleTokenizer {
                 current.setMediaQuery(current.getSelector().contains("@"));
                 current.setPseudoSelector(!current.isMediaQuery() && next.contains(":"));
             } else {
-                if (next.contains(";")) {
+                if (next.contains(";") || next.contains(":")) {
                     if (nestingLevel > 0) {
-                        nestedPropertiesBuilder.append(next).append(" } ");
+                        nestedPropertiesBuilder.append(next);
+                        if (!nestedPropertiesBuilder.toString().endsWith(";")) {
+                            nestedPropertiesBuilder.append(";");
+                        }
+                        nestedPropertiesBuilder.append(" } ");
                         nestingLevel--;
                     } else {
                         StyleTokenFactory.addProperties(current, next);

--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/util/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/util/package-info.java
@@ -18,7 +18,7 @@
  *      This package defines utility classes exposed by the Adobe Experience Manager Core Email Components Bundle.
  * </p>
  */
-@Version("5.0.0")
+@Version("5.1.0")
 package com.adobe.cq.email.core.components.util;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/email/core/components/TestFileUtils.java
+++ b/bundles/core/src/test/java/com/adobe/cq/email/core/components/TestFileUtils.java
@@ -35,6 +35,8 @@ public class TestFileUtils {
             "testpage/page_with_image_width_style_and_width_on_image_element.html";
     public final static String OUTPUT_FILE_PATH = "testpage/output_without_style.html";
     public final static String STYLE_FILE_PATH = "testpage/style.css";
+    public final static String STYLE_WITHOUT_LAST_SEMICOLON_FILE_PATH = "testpage/style_without_last_semicolon.css";
+
     public final static String STYLE_AFTER_PROCESSING_FILE_PATH = "testpage/unused_style.css";
     public final static String STYLE_AFTER_PROCESSING_WITH_IMMEDIATE_CHILDREN_FILE_PATH =
             "testpage/unused_style_with_immediate_children.css";

--- a/bundles/core/src/test/java/com/adobe/cq/email/core/components/util/StyleTokenizerTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/email/core/components/util/StyleTokenizerTest.java
@@ -24,6 +24,7 @@ import org.junit.jupiter.api.Test;
 import com.adobe.cq.email.core.components.pojo.StyleToken;
 
 import static com.adobe.cq.email.core.components.TestFileUtils.STYLE_FILE_PATH;
+import static com.adobe.cq.email.core.components.TestFileUtils.STYLE_WITHOUT_LAST_SEMICOLON_FILE_PATH;
 import static com.adobe.cq.email.core.components.TestFileUtils.compare;
 import static com.adobe.cq.email.core.components.TestFileUtils.getFileContent;
 import static org.junit.jupiter.api.Assertions.assertTrue;
@@ -43,6 +44,16 @@ class StyleTokenizerTest {
     @Test
     void success() throws URISyntaxException, IOException {
         List<StyleToken> result = StyleTokenizer.tokenize(getFileContent(STYLE_FILE_PATH));
+        StringBuilder builder = new StringBuilder();
+        for (StyleToken styleToken : result) {
+            builder.append(StyleTokenFactory.toCss(styleToken)).append("\n");
+        }
+        compare(getFileContent(STYLE_FILE_PATH), builder.toString());
+    }
+
+    @Test
+    void success_StyleWithoutLastSemicolon() throws URISyntaxException, IOException {
+        List<StyleToken> result = StyleTokenizer.tokenize(getFileContent(STYLE_WITHOUT_LAST_SEMICOLON_FILE_PATH));
         StringBuilder builder = new StringBuilder();
         for (StyleToken styleToken : result) {
             builder.append(StyleTokenFactory.toCss(styleToken)).append("\n");

--- a/bundles/core/src/test/resources/testpage/style_without_last_semicolon.css
+++ b/bundles/core/src/test/resources/testpage/style_without_last_semicolon.css
@@ -1,0 +1,76 @@
+        body {
+            font-family: 'Timmana', "Gill Sans", sans-serif
+        }
+
+        h1 {
+            font-size: 20px
+        }
+
+        h3 {
+            color: red
+        }
+
+        h1, p {
+            color: #004488;
+            Margin: 0px
+        }
+
+        p::before,
+        p::after {
+            content: '"'
+        }
+
+        img {
+            -ms-interpolation-mode: bicubic
+        }
+
+        table {
+            text-align: center !important;
+            width: 100%
+        }
+
+        table td {
+            background-color: #ccc
+        }
+
+        @media screen and (max-width: 640px) {
+            table.layout {
+                width: 100% !important
+            }
+        }
+
+        @media screen and (max-width: 480px) {
+            td.layout-column {
+                display: block !important;
+                width: 100% !important
+            }
+        }
+
+        .border {
+            border: 10px solid red
+        }
+
+        .blocked {
+            display: block;
+            display: inline-block
+        }
+
+        .ExternalClass {
+            width: 100%
+        }
+
+        .footer h3 {
+            color: darkgrey
+        }
+
+        h3.example {
+            border-bottom-width: 12px
+        }
+
+        h3.example2 {
+        	border: 3px solid green
+        }
+
+        h4 {
+        	font-weight: bold
+        }


### PR DESCRIPTION
CSS parsing enhancements

## Description

Introducing support for optional final semicolon in CSS rules. Now both of the syntaxes are supported:

**Without final semicolon:**
`image { width: 100px; height: 50px }`

**With final semicolon:**
`image { width: 100px; height: 50px; }`

## Related Issue

https://github.com/adobe/aem-core-email-components/issues/185

## Motivation and Context

Bug fix

## How Has This Been Tested?

- Local AEM instance
- jUnit tests

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
