### PR TITLE
Multiple HtmlInlinerConfiguration application for the same HTML element

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/util/HtmlAttributeInliner.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/util/HtmlAttributeInliner.java
@@ -65,7 +65,7 @@ public class HtmlAttributeInliner {
                                         p.getKey().matches(htmlInlinerConfiguration.getCssPropertyRegEx()))
                                 .findFirst().orElse(null);
                 if (Objects.isNull(cssProperty)) {
-                    return;
+                    continue;
                 }
                 Matcher matcher = pattern.matcher(cssProperty.getValue());
                 String value = null;
@@ -73,7 +73,7 @@ public class HtmlAttributeInliner {
                     value = matcher.group();
                 }
                 if (Objects.isNull(value)) {
-                    return;
+                    continue;
                 }
                 String attr = element.attr(htmlInlinerConfiguration.getHtmlAttributeName());
                 if (StringUtils.isEmpty(attr) || htmlInlinerConfiguration.isOverrideIfAlreadyExisting()) {

--- a/bundles/core/src/test/java/com/adobe/cq/email/core/components/util/HtmlAttributeInlinerTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/email/core/components/util/HtmlAttributeInlinerTest.java
@@ -155,6 +155,23 @@ class HtmlAttributeInlinerTest {
     }
 
     @Test
+    void success_MultipleHtmlInlinerConfigurationsForSameElement_NotAllProvidedAttributes() throws URISyntaxException, IOException {
+        Document document = Jsoup.parse(getFileContent(PAGE_WITH_IMAGE_WIDTH_STYLE_FILE_PATH));
+        StyleToken styleToken = StyleTokenFactory.create("img");
+        StyleTokenFactory.addProperties(styleToken, "font-family: 'Timmana', \"Gill Sans\", sans-serif;");
+        StyleTokenFactory.addProperties(styleToken, "width: 100%");
+        Element img = document.selectFirst("img");
+        assertNotNull(img);
+        List<HtmlInlinerConfiguration> htmlInlinerConfigurations = new ArrayList<>();
+        htmlInlinerConfigurations.add(HtmlInlinerConfiguration.parse("{\"elementType\":\"img\",\"cssPropertyRegEx\":\"height\"," +
+                "\"cssPropertyOutputRegEx\":\"[0-9]+(?=px)|[0-9]+(?=PX)" +
+                "|[0-9]+[%]\",\"htmlAttributeName\":\"height\",\"overrideIfAlreadyExisting\":true}"));
+        htmlInlinerConfigurations.add(HtmlInlinerConfiguration.parse(HtmlInlinerConfiguration.IMG_WIDTH_DEFAULT));
+        HtmlAttributeInliner.process(img, styleToken, htmlInlinerConfigurations);
+        assertEquals("100%", img.attr("width"));
+    }
+
+    @Test
     void success_PercentageWidth_NotExistingAttribute() throws URISyntaxException, IOException {
         Document document = Jsoup.parse(getFileContent(PAGE_WITH_IMAGE_WIDTH_STYLE_FILE_PATH));
         StyleToken styleToken = StyleTokenFactory.create("img");


### PR DESCRIPTION
- continue iteration over html attributes after css properties can't be matched
- add unit test case

fixes #184

<!--- Provide a general summary of your changes in the Title above -->

## Description

<!--- Describe your changes in detail -->

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
