### PR TITLE
Relative anchor links fix in UrlMapperService

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/services/UrlMapperServiceImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/services/UrlMapperServiceImpl.java
@@ -15,6 +15,7 @@
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
 package com.adobe.cq.email.core.components.internal.services;
 
+import java.net.URI;
 import java.util.Objects;
 
 import org.apache.commons.lang3.StringUtils;
@@ -84,6 +85,9 @@ public class UrlMapperServiceImpl implements UrlMapperService {
     @Nullable
     private String getFromExternalizer(ResourceResolver resourceResolver, String contentPath, SlingHttpServletRequest request) {
         try {
+            if (isAbsolute(contentPath) || contentPath.startsWith("#")) {
+                return contentPath;
+            }
             String externalizerMode = WCMMode.DISABLED.equals(WCMMode.fromRequest(request)) ? Externalizer.PUBLISH : Externalizer.LOCAL;
             String externalLink = externalizer.externalLink(resourceResolver, externalizerMode, contentPath);
             if (StringUtils.isNotEmpty(externalLink)) {
@@ -93,5 +97,14 @@ public class UrlMapperServiceImpl implements UrlMapperService {
             LOG.warn("Error retrieving absolute URL from externalizer: {}", e.getMessage(), e);
         }
         return null;
+    }
+
+    private boolean isAbsolute(String contentPath) {
+        try {
+            URI uri = new URI(contentPath);
+            return uri.isAbsolute();
+        } catch (Throwable e) {
+            return false;
+        }
     }
 }

--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/models/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/models/package-info.java
@@ -34,7 +34,7 @@
  *      version, is bound to this proxy component resource type.
  * </p>
  */
-@Version("13.1.0")
+@Version("13.2.0")
 package com.adobe.cq.email.core.components.models;
 
 import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/test/java/com/adobe/cq/email/core/components/internal/services/UrlMapperServiceImplTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/email/core/components/internal/services/UrlMapperServiceImplTest.java
@@ -33,8 +33,14 @@ import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class UrlMapperServiceImplTest {
-    private static final String DOMAIN = "http://domain.com";
+    private static final String HTTP_DOMAIN = "http://domain.com";
+    private static final String HTTPS_DOMAIN = "https://domain.com";
+    private static final String FTP_DOMAIN = "ftp://domain.com";
     private static final String CONTENT_PATH = "/test/content/image.jpg";
+    private static final String HTTP_CONTENT_PATH = "http://domain.com/test/content/image.jpg";
+    private static final String HTTPS_CONTENT_PATH = "https://domain.com/test/content/image.jpg";
+    private static final String FTP_CONTENT_PATH = "ftp://domain.com/test/content/image.jpg";
+    private static final String ANCHOR_CONTENT_PATH = "#anchor";
 
     @Mock
     Externalizer externalizer;
@@ -68,9 +74,9 @@ class UrlMapperServiceImplTest {
 
     @Test
     void fromResourceResolver() {
-        String resourceUrl = DOMAIN + CONTENT_PATH;
+        String resourceUrl = HTTP_DOMAIN + CONTENT_PATH;
         String requestUri = "/test/current-content-page.html";
-        StringBuffer requestUrl = new StringBuffer(DOMAIN).append(requestUri);
+        StringBuffer requestUrl = new StringBuffer(HTTP_DOMAIN).append(requestUri);
         when(request.getRequestURL()).thenReturn(requestUrl);
         when(request.getRequestURI()).thenReturn(requestUri);
         when(resourceResolver.map(any(), eq(CONTENT_PATH))).thenReturn(resourceUrl);
@@ -78,10 +84,21 @@ class UrlMapperServiceImplTest {
     }
 
     @Test
-    void fromExternalizer() {
-        String resourceUrl = DOMAIN + CONTENT_PATH;
+    void fromExternalizer_invalidUrl() {
         String requestUri = "/test/current-content-page.html";
-        StringBuffer requestUrl = new StringBuffer(DOMAIN).append(requestUri);
+        StringBuffer requestUrl = new StringBuffer(HTTP_DOMAIN).append(requestUri);
+        when(request.getRequestURL()).thenReturn(requestUrl);
+        when(request.getRequestURI()).thenReturn(requestUri);
+        String invalidUrl = "httz://\\invalid/{url}";
+        when(resourceResolver.map(any(), eq(invalidUrl))).thenReturn(null);
+        assertEquals(invalidUrl, sut.getMappedUrl(resourceResolver, request, invalidUrl));
+    }
+
+    @Test
+    void fromExternalizer() {
+        String resourceUrl = HTTP_DOMAIN + CONTENT_PATH;
+        String requestUri = "/test/current-content-page.html";
+        StringBuffer requestUrl = new StringBuffer(HTTP_DOMAIN).append(requestUri);
         when(request.getRequestURL()).thenReturn(requestUrl);
         when(request.getRequestURI()).thenReturn(requestUri);
         when(resourceResolver.map(any(), eq(CONTENT_PATH))).thenReturn(null);
@@ -90,10 +107,50 @@ class UrlMapperServiceImplTest {
     }
 
     @Test
+    void fromExternalizer_http() {
+        String requestUri = "/test/current-content-page.html";
+        StringBuffer requestUrl = new StringBuffer(HTTP_DOMAIN).append(requestUri);
+        when(request.getRequestURL()).thenReturn(requestUrl);
+        when(request.getRequestURI()).thenReturn(requestUri);
+        when(resourceResolver.map(any(), eq(HTTP_CONTENT_PATH))).thenReturn(null);
+        assertEquals(HTTP_CONTENT_PATH, sut.getMappedUrl(resourceResolver, request, HTTP_CONTENT_PATH));
+    }
+
+    @Test
+    void fromExternalizer_https() {
+        String requestUri = "/test/current-content-page.html";
+        StringBuffer requestUrl = new StringBuffer(HTTPS_DOMAIN).append(requestUri);
+        when(request.getRequestURL()).thenReturn(requestUrl);
+        when(request.getRequestURI()).thenReturn(requestUri);
+        when(resourceResolver.map(any(), eq(HTTPS_CONTENT_PATH))).thenReturn(null);
+        assertEquals(HTTPS_CONTENT_PATH, sut.getMappedUrl(resourceResolver, request, HTTPS_CONTENT_PATH));
+    }
+
+    @Test
+    void fromExternalizer_ftp() {
+        String requestUri = "/test/current-content-page.html";
+        StringBuffer requestUrl = new StringBuffer(FTP_DOMAIN).append(requestUri);
+        when(request.getRequestURL()).thenReturn(requestUrl);
+        when(request.getRequestURI()).thenReturn(requestUri);
+        when(resourceResolver.map(any(), eq(FTP_CONTENT_PATH))).thenReturn(null);
+        assertEquals(FTP_CONTENT_PATH, sut.getMappedUrl(resourceResolver, request, FTP_CONTENT_PATH));
+    }
+
+    @Test
+    void fromExternalizer_anchor() {
+        String requestUri = "/test/current-content-page.html";
+        StringBuffer requestUrl = new StringBuffer(HTTP_DOMAIN).append(requestUri);
+        when(request.getRequestURL()).thenReturn(requestUrl);
+        when(request.getRequestURI()).thenReturn(requestUri);
+        when(resourceResolver.map(any(), eq(ANCHOR_CONTENT_PATH))).thenReturn(null);
+        assertEquals(ANCHOR_CONTENT_PATH, sut.getMappedUrl(resourceResolver, request, ANCHOR_CONTENT_PATH));
+    }
+
+    @Test
     void exceptionThrownByBothMethods() {
         when(request.getRequestURL()).thenThrow(new RuntimeException("Error!"));
-        when(externalizer.externalLink(eq(resourceResolver), eq(Externalizer.PUBLISH), eq(CONTENT_PATH))).thenThrow(new RuntimeException(
-                "Error!"));
+        when(externalizer.externalLink(eq(resourceResolver), eq(Externalizer.PUBLISH), eq(CONTENT_PATH))).thenThrow(
+                new RuntimeException("Error!"));
         assertEquals(CONTENT_PATH, sut.getMappedUrl(resourceResolver, request, CONTENT_PATH));
     }
 }


### PR DESCRIPTION
Relative anchor links fix in UrlMapperService

## Description

Absolute links and relative anchor links are no more externalized.

## Related Issue

https://github.com/adobe/aem-core-email-components/issues/206

## Motivation and Context

Bug fix

## How Has This Been Tested?

- Local AEM instance
- jUnit test

## Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [X] I have added tests to cover my changes.
- [X] All new and existing tests passed.
