### PR TITLE
Remove Campaign related warnings

### DIFF
--- a/content/src/content/jcr_root/apps/core/email/components/page/v1/page/page.html
+++ b/content/src/content/jcr_root/apps/core/email/components/page/v1/page/page.html
@@ -25,13 +25,6 @@
 <body class="${page.cssClassNames}"
       id="${page.id}"
       data-cmp-data-layer-enabled="${page.data ? true : false}">
-    <sly data-sly-test="${emailPage.statusMessage}">
-        <div class="coral-Alert coral-Alert--${emailPage.alertType} coral--light" style="margin:0; border-radius:0; -moz-border-radius:0; -webkit-border-radius:0;">
-            <i class="coral-Alert-typeIcon coral-Icon coral-Icon--sizeS coral-Icon--adobeCampaign"></i>
-            <strong class="coral-Alert-title">${emailPage.statusHeader}</strong>
-            <div class="coral-Alert-message">${emailPage.statusMessage}</div>
-        </div>
-    </sly>
     <sly data-sly-include="body.html"></sly>
     <sly data-sly-call="${footer.footer @ page = page, pwa = pwa}"></sly>
 <sly data-sly-test="${wcmmode.edit}" data-sly-call="${clientlib.all @ categories='cq.authoring.editor.plugin.campaign'}"></sly>


### PR DESCRIPTION
Summary: Remove Campaign related warnings on an AEMaaCS instance that doesn't have a Campaign integration

### Description
There is a section that is showing coral-Alert based on emailPage.statusHeader
The EmailPage is implemented by [https://github.com/adobe/aem-core-email-components/blob/development/bundles/core/s[…]obe/cq/email/core/components/internal/models/EmailPageImpl.java](https://github.com/adobe/aem-core-email-components/blob/development/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/models/EmailPageImpl.java#L152) which - once constructed - is filling this data based on the initialization of the Adobe Campaign connector (it will always be set as having errors if the webservice config is not defined)
=> currently commented out the coral-Alert (Missing campaign webservice config) as the EmailPage component has been extended to integrate with AJO and other products, which are not strictly using Adobe Campaign.

### Issue
Ticket and details [here](https://jira.corp.adobe.com/browse/SITES-7251)

### How Has This Been Tested?
Manually tested on a dev AEMaaCS environment (see SITES-7251 ticket)

### Screenshots (if appropriate):
![image](https://user-images.githubusercontent.com/17162246/187897724-2be69959-d1c0-4098-bd7f-f3b382a03b55.png)


## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
