### PR TITLE
SITES-8232: remove adobeCampaign buttons from RTE

### DIFF
--- a/content/src/content/jcr_root/apps/core/email/components/text/v1/text/_cq_dialog/.content.xml
+++ b/content/src/content/jcr_root/apps/core/email/components/text/v1/text/_cq_dialog/.content.xml
@@ -55,9 +55,6 @@
                                                 name="./text"
                                                 useFixedInlineToolbar="{Boolean}true">
                                                 <rtePlugins jcr:primaryType="nt:unstructured">
-                                                    <personalizationplugin
-                                                        jcr:primaryType="nt:unstructured"
-                                                        features="*"/>
                                                     <format
                                                         jcr:primaryType="nt:unstructured"
                                                         features="bold,italic"/>

--- a/content/src/content/jcr_root/apps/core/email/components/text/v1/text/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/email/components/text/v1/text/_cq_editConfig.xml
@@ -10,9 +10,6 @@
             jcr:primaryType="nt:unstructured"
             disableXSSFiltering="{Boolean}true">
             <rtePlugins jcr:primaryType="nt:unstructured">
-                <personalizationplugin
-                    jcr:primaryType="nt:unstructured"
-                    features="*"/>
                 <tracklinks
                     jcr:primaryType="nt:unstructured"
                     features="*"/>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

- Remove the adobeCampaign buttons from RTE component  when Campaign is not configured/installed on an AEMaaCS instance
-  Issue coming from _personalizationplugin_
-  Appears not to be a Campaign specific issue as there is in place a logic to detect if campaign hasn't been installed on an instance and hence hides the campaign buttons
<img width="1200" alt="Screenshot 2022-10-19 at 12 44 40" src="https://user-images.githubusercontent.com/17162246/196657405-e41921eb-4828-43fc-8979-277b30e9c249.png">


## Related Issue
Ticket and details: https://jira.corp.adobe.com/browse/SITES-8232

## How Has This Been Tested?
Verified on a skyline instance - details in the ticket above

## Screenshots (if appropriate):
Attached below
## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)