### PR TITLE
fix: div removal fails with nested structures and siblings

### DIFF
--- a/bundles/core/pom.xml
+++ b/bundles/core/pom.xml
@@ -384,7 +384,7 @@
         </dependency>
         <dependency>
             <groupId>org.slf4j</groupId>
-            <artifactId>slf4j-nop</artifactId>
+            <artifactId>slf4j-simple</artifactId>
             <scope>test</scope>
         </dependency>
         <dependency>

--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/util/WrapperDivRemover.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/util/WrapperDivRemover.java
@@ -59,11 +59,10 @@ public class WrapperDivRemover {
             return;
         }
         for (Element child : children) {
+            removeWrapperDivs(child, child.children(), wrapperDivClassesToBeRemoved);
+
             if (child.tagName().equalsIgnoreCase("div") && containsClassToBeRemoved(child, wrapperDivClassesToBeRemoved)) {
                 child.unwrap();
-                removeWrapperDivs(parent, parent.children(), wrapperDivClassesToBeRemoved);
-            } else {
-                removeWrapperDivs(child, child.children(), wrapperDivClassesToBeRemoved);
             }
         }
     }

--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/util/WrapperDivRemover.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/util/WrapperDivRemover.java
@@ -20,6 +20,7 @@ import java.util.Objects;
 import org.apache.commons.lang3.StringUtils;
 import org.jsoup.nodes.Document;
 import org.jsoup.nodes.Element;
+import org.jsoup.nodes.Node;
 import org.jsoup.select.Elements;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/bundles/core/src/test/java/com/adobe/cq/email/core/components/internal/util/WrapperDivRemoverTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/email/core/components/internal/util/WrapperDivRemoverTest.java
@@ -23,7 +23,6 @@ import org.jsoup.nodes.Document;
 import org.junit.jupiter.api.Test;
 
 import com.adobe.cq.email.core.components.TestFileUtils;
-import com.adobe.cq.email.core.components.internal.util.WrapperDivRemover;
 
 import static com.adobe.cq.email.core.components.TestFileUtils.compareRemovingNewLinesAndTabs;
 
@@ -54,5 +53,14 @@ class WrapperDivRemoverTest {
         WrapperDivRemover.removeWrapperDivs(document, new String[]{"responsivegrid", "aem-Grid", "aem-GridColumn", "cmp-title__text"});
         compareRemovingNewLinesAndTabs(TestFileUtils.getFileContent(TestFileUtils.WRAPPER_DIV_REMOVAL_OUTPUT_DIVS_REMOVED_FILE_PATH),
                 document.outerHtml());
+    }
+
+    @Test
+    void removeDivsSiblings() throws URISyntaxException, IOException {
+        String html = TestFileUtils.getFileContent("wrapper-div-removal/input_remove_siblings_issue.html");
+        Document document = Jsoup.parse(html);
+        WrapperDivRemover.removeWrapperDivs(document, new String[]{"remove"});
+        compareRemovingNewLinesAndTabs(TestFileUtils.getFileContent("wrapper-div-removal/output_remove_siblings_issue.html"),
+            document.outerHtml());
     }
 }

--- a/bundles/core/src/test/resources/wrapper-div-removal/input_remove_siblings_issue.html
+++ b/bundles/core/src/test/resources/wrapper-div-removal/input_remove_siblings_issue.html
@@ -1,0 +1,39 @@
+<!DOCTYPE HTML>
+<html lang="it-IT">
+<head>
+    <meta charset="UTF-8"/>
+    <title>test</title>
+    <meta name="template" content="email-template"/>
+    <meta name="viewport" content="width=device-width, initial-scale=1"/>
+    <link rel="stylesheet" href="/etc.clientlibs/core-email-components-examples/clientlibs/clientlib-base.css" type="text/css">
+    <link rel="canonical" href="http://192.168.1.50:4503/content/campaigns/core-email-components-examples/master/core-email-spender/test.html"/>
+</head>
+
+<body class="page basicpage" id="page-5ca4668d10">
+    <div class="root responsivegrid">
+        <div class="keep">
+            <div class="remove">
+                <div class="remove"><span>1</span></div>
+                <div class="keep"><span>2</span></div>
+                <div class="remove"><span>3</span></div>
+            </div>
+            <div class="remove">
+                <div class="remove"><span>4</span></div>
+                <div class="remove"><span>5</span></div>
+            </div>
+        </div>
+        <div class="keep">
+            <div class="remove">
+                <div class="remove"><span>6</span></div>
+                <div class="keep"><span>7</span></div>
+                <div class="remove"><span>8</span></div>
+            </div>
+            <div class="remove">
+                <div class="remove"><span>9</span></div>
+                <div class="remove"><span>10</span></div>
+            </div>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/bundles/core/src/test/resources/wrapper-div-removal/output_remove_siblings_issue.html
+++ b/bundles/core/src/test/resources/wrapper-div-removal/output_remove_siblings_issue.html
@@ -1,0 +1,31 @@
+<!doctype html>
+<html lang="it-IT">
+<head>
+    <meta charset="UTF-8">
+    <title>test</title>
+    <meta name="template" content="email-template">
+    <meta name="viewport" content="width=device-width, initial-scale=1">
+    <link rel="stylesheet" href="/etc.clientlibs/core-email-components-examples/clientlibs/clientlib-base.css" type="text/css">
+    <link rel="canonical" href="http://192.168.1.50:4503/content/campaigns/core-email-components-examples/master/core-email-spender/test.html">
+</head>
+
+<body class="page basicpage" id="page-5ca4668d10">
+    <div class="root responsivegrid">
+        <div class="keep">
+            <span>1</span>
+            <div class="keep"><span>2</span></div>
+            <span>3</span>
+            <span>4</span>
+            <span>5</span>
+        </div>
+        <div class="keep">
+            <span>6</span>
+            <div class="keep"><span>7</span></div>
+            <span>8</span>
+            <span>9</span>
+            <span>10</span>
+        </div>
+    </div>
+</body>
+
+</html>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -852,7 +852,7 @@
             </dependency>
             <dependency>
                 <groupId>org.slf4j</groupId>
-                <artifactId>slf4j-nop</artifactId>
+                <artifactId>slf4j-simple</artifactId>
                 <version>${slf4j.version}</version>
                 <scope>test</scope>
             </dependency>


### PR DESCRIPTION
In a tree where two divs-to-keep contain multiple divs-to-remove siblings, the traversal fails with an exception as the children of a parent are processed twice and in the second iteration a div-to-remove as no parent anymore.

Example from the unit test provided:

```
<div class="keep">
            <div class="remove">
                <div class="remove"><span>1</span></div>
                <div class="keep"><span>2</span></div>
                <div class="remove"><span>3</span></div>
            </div>
            <div class="remove">
                <div class="remove"><span>4</span></div>
                <div class="remove"><span>5</span></div>
            </div>
        </div>
        <div class="keep">
            <div class="remove">
                <div class="remove"><span>6</span></div>
                <div class="keep"><span>7</span></div>
                <div class="remove"><span>8</span></div>
            </div>
            <div class="remove">
                <div class="remove"><span>9</span></div>
                <div class="remove"><span>10</span></div>
            </div>
        </div>
```