### PR TITLE
fix: move Editor into exported package

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/email/core/commons/editor/dialog/segmenteditor/Condition.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/commons/editor/dialog/segmenteditor/Condition.java
@@ -1,0 +1,35 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.email.core.commons.editor.dialog.segmenteditor;
+
+public class Condition {
+
+    private final String name;
+    private final String value;
+
+    public Condition(String name, String value) {
+        this.name = name;
+        this.value = value;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getValue() {
+        return value;
+    }
+}

--- a/bundles/core/src/main/java/com/adobe/cq/email/core/commons/editor/dialog/segmenteditor/Editor.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/commons/editor/dialog/segmenteditor/Editor.java
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-package com.adobe.cq.email.core.components.internal.commons.editor.dialog.segmenteditor;
+package com.adobe.cq.email.core.commons.editor.dialog.segmenteditor;
 
 import java.util.ArrayList;
 import java.util.Collections;

--- a/bundles/core/src/main/java/com/adobe/cq/email/core/commons/editor/dialog/segmenteditor/SegmentItem.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/commons/editor/dialog/segmenteditor/SegmentItem.java
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-package com.adobe.cq.email.core.components.internal.commons.editor.dialog.segmenteditor;
+package com.adobe.cq.email.core.commons.editor.dialog.segmenteditor;
 
 import org.apache.sling.api.SlingHttpServletRequest;
 import org.apache.sling.api.resource.Resource;

--- a/bundles/core/src/main/java/com/adobe/cq/email/core/commons/editor/dialog/segmenteditor/package-info.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/commons/editor/dialog/segmenteditor/package-info.java
@@ -13,23 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-package com.adobe.cq.email.core.components.internal.commons.editor.dialog.segmenteditor;
+@Version("1.0.0")
+package com.adobe.cq.email.core.commons.editor.dialog.segmenteditor;
 
-public class Condition {
-
-    private final String name;
-    private final String value;
-
-    public Condition(String name, String value) {
-        this.name = name;
-        this.value = value;
-    }
-
-    public String getName() {
-        return name;
-    }
-
-    public String getValue() {
-        return value;
-    }
-}
+import org.osgi.annotation.versioning.Version;

--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/models/SegmentationImpl.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/models/SegmentationImpl.java
@@ -23,7 +23,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.Optional;
-import java.util.function.Predicate;
 import java.util.stream.Collectors;
 import java.util.stream.StreamSupport;
 
@@ -45,8 +44,8 @@ import org.jetbrains.annotations.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import com.adobe.cq.email.core.components.internal.commons.editor.dialog.segmenteditor.Editor;
-import com.adobe.cq.email.core.components.internal.commons.editor.dialog.segmenteditor.SegmentItem;
+import com.adobe.cq.email.core.commons.editor.dialog.segmenteditor.Editor;
+import com.adobe.cq.email.core.commons.editor.dialog.segmenteditor.SegmentItem;
 import com.adobe.cq.email.core.components.models.Segmentation;
 import com.adobe.cq.export.json.ComponentExporter;
 import com.adobe.cq.wcm.core.components.commons.link.Link;
@@ -58,9 +57,7 @@ import com.day.cq.commons.jcr.JcrConstants;
 import com.day.cq.wcm.api.WCMException;
 import com.day.cq.wcm.api.WCMMode;
 import com.day.cq.wcm.api.components.ComponentManager;
-import com.day.cq.wcm.msm.api.LiveRelationship;
 import com.day.cq.wcm.msm.api.LiveRelationshipManager;
-import com.day.cq.wcm.msm.api.LiveStatus;
 
 @Model(
         adaptables = SlingHttpServletRequest.class,

--- a/bundles/core/src/test/java/com/adobe/cq/email/core/commons/editor/dialog/segmenteditor/EditorTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/email/core/commons/editor/dialog/segmenteditor/EditorTest.java
@@ -13,7 +13,7 @@
  ~ See the License for the specific language governing permissions and
  ~ limitations under the License.
  ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
-package com.adobe.cq.email.core.components.internal.commons.editor.dialog.segmenteditor;
+package com.adobe.cq.email.core.commons.editor.dialog.segmenteditor;
 
 import com.day.cq.wcm.api.policies.ContentPolicyMapping;
 import com.google.common.collect.ImmutableMap;

--- a/content/src/content/jcr_root/apps/core/email/components/commons/editor/dialog/segmenteditor/v1/segmenteditor/segmenteditor.html
+++ b/content/src/content/jcr_root/apps/core/email/components/commons/editor/dialog/segmenteditor/v1/segmenteditor/segmenteditor.html
@@ -13,7 +13,7 @@
   ~ See the License for the specific language governing permissions and
   ~ limitations under the License.
   ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/-->
-<coral-multifield data-sly-use.segmentEditor="com.adobe.cq.email.core.components.internal.commons.editor.dialog.segmenteditor.Editor"
+<coral-multifield data-sly-use.segmentEditor="com.adobe.cq.email.core.commons.editor.dialog.segmenteditor.Editor"
                   data-sly-use.iconTemplate="icon.html"
                   data-cmp-is="segmentEditor"
                   class="cmp-segmenteditor"


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

With #217 most of the previously exported packages were made private, including the one one containing the `Editor` model. This made the model inaccessible to the htl script though, making the dialog of the Segmentation Component to fail rendering.

This change reverts this change for the `Editor`.

## Related Issue

#217 
SITES-7278

## Motivation and Context

Regression

## How Has This Been Tested?

Locally

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [X] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [X] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
