### PR TITLE
SITES-7811: move the status bar logic into a resource status provider

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/services/CampaignStatusProvider.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/services/CampaignStatusProvider.java
@@ -1,0 +1,233 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.email.core.components.internal.services;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.sling.api.resource.Resource;
+import org.apache.sling.i18n.ResourceBundleProvider;
+import org.jetbrains.annotations.NotNull;
+import org.jetbrains.annotations.Nullable;
+import org.osgi.service.component.annotations.Component;
+import org.osgi.service.component.annotations.Reference;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.adobe.cq.email.core.components.internal.models.EmailPageImpl;
+import com.adobe.cq.mcm.campaign.LinkingStatus;
+import com.adobe.cq.mcm.campaign.LinkingStatusService;
+import com.adobe.cq.mcm.campaign.NewsletterException;
+import com.adobe.granite.resourcestatus.ResourceStatus;
+import com.adobe.granite.resourcestatus.ResourceStatusProvider;
+import com.day.cq.i18n.I18n;
+import com.day.cq.mcm.campaign.ACConnectorException;
+import com.day.cq.mcm.campaign.CampaignConnector;
+import com.day.cq.mcm.campaign.NewsletterStatus;
+import com.day.cq.mcm.campaign.StatusService;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.api.PageManager;
+import com.day.cq.wcm.api.PageManagerFactory;
+import com.day.cq.wcm.commons.status.EditorResourceStatus;
+import com.day.cq.wcm.webservicesupport.Configuration;
+
+@Component(service = ResourceStatusProvider.class)
+public class CampaignStatusProvider implements ResourceStatusProvider {
+
+    private static final Logger LOG = LoggerFactory.getLogger(CampaignStatusProvider.class);
+
+    @Reference
+    private PageManagerFactory pageManagerFactory;
+    @Reference
+    private CampaignConnector connector;
+    @Reference
+    private StatusService statusService;
+    @Reference
+    private LinkingStatusService linkingStatusService;
+    @Reference
+    private ResourceBundleProvider resourceBundleProvider;
+
+    @NotNull
+    @Override
+    public String getType() {
+        return "adobe-campaign";
+    }
+
+    @Nullable
+    @Override
+    public List<ResourceStatus> getStatuses(Resource resource) {
+        PageManager pageManager = pageManagerFactory.getPageManager(resource.getResourceResolver());
+        Page page = pageManager.getPage(resource.getPath());
+
+        if (page == null) {
+            page = pageManager.getContainingPage(resource);
+        }
+
+        Resource contentResource = page != null ? page.getContentResource() : null;
+        StatusBuilder status = getStatusBuilder(contentResource);
+
+        return status != null ? Collections.singletonList(status.build()) : Collections.emptyList();
+    }
+
+    private StatusBuilder getStatusBuilder(Resource contentResource) {
+        // implementing the same logic as in /libs/mcm/campaign/components/status/status.jsp
+        if (contentResource != null && contentResource.isResourceType(EmailPageImpl.RESOURCE_TYPE)) {
+            Configuration wsConfig;
+            String message = null;
+            String snippet = null;
+            String title = "Status";
+            Status.Variant variant = EditorResourceStatus.Variant.INFO;
+
+            // check if cloud service configuration is available
+            try {
+                wsConfig = connector.getWebserviceConfig(contentResource);
+            } catch (ACConnectorException ex) {
+                LOG.debug("Could not get adobe campaign webservice configuration for {}", contentResource.getPath(), ex);
+                // return null to not show any status in this case (e.g. for AJO)
+                return null;
+            }
+
+            try {
+                connector.retrieveCredentials(wsConfig);
+            } catch (ACConnectorException ex) {
+                LOG.warn("Could not get adobe campaign webservice credentials for {}", contentResource.getPath(), ex);
+                return newStatus(title, "Could not determine webservice credentials.", EditorResourceStatus.Variant.WARNING);
+            }
+
+            I18n i18n = new I18n(resourceBundleProvider.getResourceBundle(resourceBundleProvider.getDefaultLocale()));
+
+            // status
+            try {
+                NewsletterStatus status = statusService.retrieveStatus(contentResource, i18n);
+                int statusCode = status.getStatusCode();
+                if (statusCode != NewsletterStatus.UNAVAILABLE) {
+                    if (statusCode < 0) {
+                        title = "Remote status";
+                    }
+                    message = status.getStatusMessage();
+                }
+                if (statusCode == NewsletterStatus.FAILED) {
+                    variant = EditorResourceStatus.Variant.ERROR;
+                } else if (statusCode == NewsletterStatus.MISSING || statusCode == NewsletterStatus.UNAVAILABLE) {
+                    variant = EditorResourceStatus.Variant.WARNING;
+                }
+
+                if (message != null) {
+                    return newStatus(title, message, variant);
+                }
+            } catch (ACConnectorException ex) {
+                LOG.warn("Could not get status from adobe campaign for {}", contentResource.getPath(), ex);
+            }
+
+            // linking status
+            try {
+                LinkingStatus status = linkingStatusService.retrieveStatus(contentResource, i18n);
+                String[] linked = status.getLinkedDeliveries();
+                if (linked.length > 0) {
+                    if (linked.length == 1) {
+                        message = "Linked with delivery {0}";
+                        snippet = linked[0];
+                    } else {
+                        message = "Linked with {0} deliveries";
+                        snippet = Integer.toString(linked.length);
+                    }
+                    variant = EditorResourceStatus.Variant.INFO;
+                }
+                if (status.isApproved()) {
+                    if (message == null) {
+                        message = i18n.get("Approved");
+                    } else {
+                        message += i18n.get(" and approved");
+                    }
+                    variant = EditorResourceStatus.Variant.INFO;
+                }
+                if (message != null) {
+                    return newStatus(title, message + ".", variant).addSnippet(snippet);
+                }
+            } catch (NewsletterException ex) {
+                LOG.warn("Cloud not get linking status from adobe campaign for {}", contentResource.getPath(), ex);
+            }
+        }
+
+        return null;
+    }
+
+    private StatusBuilder newStatus(String title, String msg, EditorResourceStatus.Variant variant) {
+        return new StatusBuilder(getType(), title, msg).setVariant(variant);
+    }
+
+    private static class Status extends EditorResourceStatus {
+        private final List<String> snippets;
+
+        public Status(EditorResourceStatus status, List<String> snippets) {
+            super(status.getType(), status.getTitle(), status.getMessage(), status.getPriority(), status.getVariant(), status.getIcon(),
+                status.getActions(), status.getAdditionalData());
+            this.snippets = snippets != null ? new ArrayList<>(snippets) : null;
+        }
+
+        @Nullable
+        @Override
+        public Map<String, Object> getData() {
+            Map<String, Object> data = super.getData();
+
+            if (data == null || data.isEmpty() || snippets == null) {
+                return data;
+            }
+
+            // create a copy of the data and add the message snippets
+            data = new HashMap<>(data);
+            data.put("i18n.message.snippets", snippets);
+
+            return Collections.unmodifiableMap(data);
+        }
+    }
+
+    private static class StatusBuilder extends EditorResourceStatus.Builder {
+        private List<String> snippets;
+
+        public StatusBuilder(@NotNull String type, @NotNull String title, @NotNull String message) {
+            super(type, title, message);
+        }
+
+
+        @NotNull
+        @Override
+        public CampaignStatusProvider.StatusBuilder setVariant(@Nullable EditorResourceStatus.Variant variant) {
+            super.setVariant(variant);
+            return this;
+        }
+
+        public StatusBuilder addSnippet(String snippet) {
+            if (StringUtils.isNotEmpty(snippet)) {
+                if (snippets == null) {
+                    snippets = new ArrayList<>(1);
+                }
+                snippets.add(snippet);
+            }
+            return this;
+        }
+
+        @Override
+        public EditorResourceStatus build() {
+            return new Status(super.build(), snippets);
+        }
+    }
+
+}

--- a/bundles/core/src/test/java/com/adobe/cq/email/core/components/internal/services/CampaignStatusProviderTest.java
+++ b/bundles/core/src/test/java/com/adobe/cq/email/core/components/internal/services/CampaignStatusProviderTest.java
@@ -1,0 +1,218 @@
+/*~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+ ~ Copyright 2022 Adobe
+ ~
+ ~ Licensed under the Apache License, Version 2.0 (the "License");
+ ~ you may not use this file except in compliance with the License.
+ ~ You may obtain a copy of the License at
+ ~
+ ~     http://www.apache.org/licenses/LICENSE-2.0
+ ~
+ ~ Unless required by applicable law or agreed to in writing, software
+ ~ distributed under the License is distributed on an "AS IS" BASIS,
+ ~ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ ~ See the License for the specific language governing permissions and
+ ~ limitations under the License.
+ ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~*/
+package com.adobe.cq.email.core.components.internal.services;
+
+import java.util.List;
+import java.util.Map;
+
+import org.apache.commons.lang3.StringUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+import com.adobe.cq.email.core.components.internal.models.EmailPageImpl;
+import com.adobe.cq.mcm.campaign.LinkingStatus;
+import com.adobe.cq.mcm.campaign.LinkingStatusService;
+import com.adobe.cq.mcm.campaign.NewsletterException;
+import com.adobe.cq.wcm.core.components.testing.MockExternalizerFactory;
+import com.adobe.granite.resourcestatus.ResourceStatus;
+import com.day.cq.commons.Externalizer;
+import com.day.cq.mcm.campaign.ACConnectorException;
+import com.day.cq.mcm.campaign.CampaignConnector;
+import com.day.cq.mcm.campaign.NewsletterStatus;
+import com.day.cq.mcm.campaign.StatusService;
+import com.day.cq.wcm.api.Page;
+import com.day.cq.wcm.webservicesupport.Configuration;
+import com.google.common.collect.ImmutableMap;
+import io.wcm.testing.mock.aem.junit5.AemContext;
+import io.wcm.testing.mock.aem.junit5.AemContextBuilder;
+import io.wcm.testing.mock.aem.junit5.AemContextExtension;
+
+import static com.adobe.cq.wcm.core.components.testing.mock.ContextPlugins.CORE_COMPONENTS;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@ExtendWith({ AemContextExtension.class })
+public class CampaignStatusProviderTest {
+
+    public final AemContext context = new AemContextBuilder()
+        .beforeSetUp(context -> {
+            context.registerService(Externalizer.class, MockExternalizerFactory.getExternalizerService());
+        })
+        .plugin(CORE_COMPONENTS)
+        .build();
+
+    final LinkingStatusService linkingStatusService = mock(LinkingStatusService.class);
+    final StatusService statusService = mock(StatusService.class);
+    final CampaignConnector campaignConnector = mock(CampaignConnector.class);
+    final CampaignStatusProvider subject = new CampaignStatusProvider();
+
+    Page page;
+
+    @BeforeEach
+    void setup() {
+        context.registerService(CampaignConnector.class, campaignConnector);
+        context.registerService(LinkingStatusService.class, linkingStatusService);
+        context.registerService(StatusService.class, statusService);
+
+        context.registerInjectActivateService(subject);
+
+        page = context.create().page("/content/campaigns/brand/master/campaign/email", "email", ImmutableMap.of(
+            "sling:resourceType", EmailPageImpl.RESOURCE_TYPE
+        ));
+    }
+
+    @Test
+    void testReturnsNothingForNonEmailPages() {
+        Page page = context.create().page("/path/to/page");
+        testSubject(page);
+    }
+
+    @Test
+    void testReturnsNothingWithNotCloudService() throws ACConnectorException {
+        doThrow(ACConnectorException.class).when(campaignConnector).getWebserviceConfig(any());
+
+        testSubject();
+    }
+
+    @Test
+    void testReturnsWarningWithUnavailableCredentials() throws ACConnectorException {
+        doReturn(mock(Configuration.class)).when(campaignConnector).getWebserviceConfig(any());
+        doThrow(ACConnectorException.class).when(campaignConnector).retrieveCredentials(any());
+
+        testSubject(new Expectation("Status", "Could not determine webservice credentials.", "warning"));
+    }
+
+    @Test
+    void testReturnsNothingIfUnavailable() throws ACConnectorException, NewsletterException {
+        setupStatus(NewsletterStatus.UNAVAILABLE, null);
+        testSubject();
+    }
+
+    @Test
+    void testReturnsErrorIfFailed() throws ACConnectorException, NewsletterException {
+        setupStatus(NewsletterStatus.FAILED, "Expected");
+        testSubject(new Expectation("Remote status", "Expected", "error"));
+    }
+
+    @Test
+    void testReturnsInfoIfPreparing() throws ACConnectorException, NewsletterException {
+        setupStatus(NewsletterStatus.PREPARING, "Expected");
+        testSubject(new Expectation("Remote status", "Expected", "info"));
+    }
+
+    @Test
+    void testReturnsWarningIfMissing() throws ACConnectorException, NewsletterException {
+        setupStatus(NewsletterStatus.MISSING, "Expected");
+        testSubject(new Expectation("Remote status", "Expected", "warning"));
+    }
+
+    @ParameterizedTest
+    @CsvSource(value = {
+        "Linked with delivery {0}.;false;DM1",
+        "Linked with delivery {0} and approved.;true;DM1",
+        "Linked with {0} deliveries.;false;DM1,DM2",
+        "Linked with {0} deliveries and approved.;true;DM1,DM2,DM3",
+        "Approved.;true;",
+    }, delimiter = ';')
+    void testReturnsLinkedDeliveries(String expected, boolean approved, String deliveries) throws ACConnectorException, NewsletterException {
+        Expectation expectation = new Expectation("Status", expected, "info");
+
+        if (StringUtils.isNotEmpty(deliveries)) {
+            String[] arr = deliveries.split(",");
+            setupStatus(NewsletterStatus.UNAVAILABLE, "Expected", approved, arr);
+            if (arr.length == 1) {
+                expectation.placeholder = arr[0];
+            } else {
+                expectation.placeholder = Integer.toString(arr.length);
+            }
+        } else {
+            setupStatus(NewsletterStatus.UNAVAILABLE, "Expected", approved);
+        }
+
+        testSubject(expectation);
+    }
+
+    @Test
+    void testReturnsNothingIfNotApprovedAndNotLinked() throws ACConnectorException, NewsletterException {
+        setupStatus(NewsletterStatus.UNAVAILABLE, null, false);
+        testSubject();
+    }
+
+    private void setupStatus(int code, String message) throws ACConnectorException, NewsletterException {
+        setupStatus(code, message, false);
+    }
+
+    private void setupStatus(int code, String message, boolean approved, String... deliveries)
+        throws ACConnectorException, NewsletterException {
+        NewsletterStatus status = mock(NewsletterStatus.class);
+        when(status.getStatusCode()).thenReturn(code);
+        when(status.getStatusMessage()).thenReturn(message);
+        when(statusService.retrieveStatus(any(), any())).thenReturn(status);
+        LinkingStatus linkingStatus = new LinkingStatus(approved, deliveries);
+        when(linkingStatusService.retrieveStatus(any(), any())).thenReturn(linkingStatus);
+    }
+
+    private void testSubject(Expectation... expectations) {
+        testSubject(page, expectations);
+    }
+
+    private void testSubject(Page target, Expectation... expectations) {
+        List<ResourceStatus> statuses = subject.getStatuses(target.getContentResource());
+
+        if (expectations.length == 0) {
+            assertTrue(statuses.isEmpty());
+        } else {
+            assertEquals(expectations.length, statuses.size());
+            for (int i = 0; i < expectations.length; i++) {
+                Expectation expectation = expectations[i];
+                Map<String, Object> status = statuses.get(i).getData();
+                assertEquals(expectation.title, status.get("title"));
+                assertEquals(expectation.message, status.get("message"));
+                assertEquals(expectation.variant, status.get("variant"));
+                if (expectation.placeholder != null) {
+                    assertNotNull(status.get("i18n.message.snippets"));
+                    assertTrue(status.get("i18n.message.snippets") instanceof List);
+                    List snippets = (List) status.get("i18n.message.snippets");
+                    assertEquals(1, snippets.size());
+                    assertEquals(expectation.placeholder, snippets.get(0));
+                }
+            }
+        }
+    }
+
+    private static class Expectation {
+
+        private String title;
+        private String message;
+        private String variant;
+        private String placeholder;
+
+        public Expectation(String title, String message, String variant) {
+            this.title = title;
+            this.message = message;
+            this.variant = variant;
+        }
+    }
+}

--- a/examples/ui.content/src/content/jcr_root/content/campaigns/core-email-components-examples/master/.content.xml
+++ b/examples/ui.content/src/content/jcr_root/content/campaigns/core-email-components-examples/master/.content.xml
@@ -2,7 +2,6 @@
 <jcr:root xmlns:sling="http://sling.apache.org/jcr/sling/1.0" xmlns:cq="http://www.day.com/jcr/cq/1.0" xmlns:jcr="http://www.jcp.org/jcr/1.0" xmlns:nt="http://www.jcp.org/jcr/nt/1.0"
     jcr:primaryType="cq:Page">
     <jcr:content
-        cq:cloudserviceconfigs="[]"
         cq:lastModified="{Date}2022-03-07T14:00:00.308Z"
         cq:lastModifiedBy="stein"
         cq:template="/libs/cq/personalization/templates/ambit"


### PR DESCRIPTION
In https://github.com/adobe/aem-core-email-components/commit/93ef3d4ab776b2799403bc8e9431234ea12983bf we removed the campaign specific status bar from the page. This change reintroduces the status bar as resource status provider which is used by the editor to show the status bar in the editor frame instead. The necessary configuration to the editor composite status provider will be made available by the product.

The logic was copied from the existing status.jsp, however it does not show a status when there is no AC cloud configuration. This is necessary to also support other outbound marketing initiatives like AJO. 