### PR TITLE
Moved wiki component content into individual readmes

### DIFF
--- a/content/src/content/jcr_root/apps/core/email/components/button/v1/button/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/button/v1/button/readme.md
@@ -13,9 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-Button
-====
-Extensible button component written in HTL for composing campaign content and based on the [Button Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/button/v2/button)
+# Button Component
+
+Extensible button component for the Core Email Components for composing campaign content written in HTL and based on the [Button Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/button/v2/button)
 
 ## Features
 * Supports editable templates
@@ -37,7 +37,7 @@ The following properties are written to JCR for this Page component and are expe
 ## Information
 * **Vendor**: Adobe
 * **Version**: v1
-* **Compatibility**: AEM 6.5, AEM as a Cloud Service
+* **Compatibility**: AEM 6.5
 * **Status**: production-ready
 * **User Documentation**: [https://www.adobe.com/go/aem_cmp_email_page_v1](https://www.adobe.com/go/aem_cmp_email_page_v1)
 * **Authors**: 

--- a/content/src/content/jcr_root/apps/core/email/components/button/v1/button/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/button/v1/button/readme.md
@@ -18,6 +18,7 @@ limitations under the License.
 Extensible button component for the Core Email Components for composing campaign content written in HTL and based on the [Button Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/button/v2/button)
 
 ## Features
+
 * Supports editable templates
 * Title, description, tagging, and language definition
 * HTML ID
@@ -37,6 +38,7 @@ This component inherit its structure and behavior from the [Button component (v2
 The class `ButtonIT` is the Selenium test class. It checks for the existence of the personalization buttons in each of the previously mentioned windows.
 
 ## Information
+
 * **Vendor**: Adobe
 * **Version**: v1
 * **Compatibility**: AEM 6.5

--- a/content/src/content/jcr_root/apps/core/email/components/button/v1/button/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/button/v1/button/readme.md
@@ -13,9 +13,9 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-Page
+Button
 ====
-Extensible page component written in HTL for composing campaign content and based on the [Page Core Component](https://github.com/adobe/aem-core-wcm-components/blob/main/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/README.md)
+Extensible button component written in HTL for composing campaign content and based on the [Button Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/button/v2/button)
 
 ## Features
 * Supports editable templates
@@ -28,9 +28,6 @@ Extensible page component written in HTL for composing campaign content and base
 ## Use Object
 The Page component uses the following use objects:
 
-* `com.adobe.cq.wcm.core.components.models.Page`
-* `com.day.cq.wcm.foundation.TemplatedContainer`
-
 ## Component Policy Configuration Properties
 The following configuration properties are used:
 
@@ -40,7 +37,7 @@ The following properties are written to JCR for this Page component and are expe
 ## Information
 * **Vendor**: Adobe
 * **Version**: v1
-* **Compatibility**: AEM 6.5
+* **Compatibility**: AEM 6.5, AEM as a Cloud Service
 * **Status**: production-ready
 * **User Documentation**: [https://www.adobe.com/go/aem_cmp_email_page_v1](https://www.adobe.com/go/aem_cmp_email_page_v1)
 * **Authors**: 

--- a/content/src/content/jcr_root/apps/core/email/components/button/v1/button/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/button/v1/button/readme.md
@@ -25,14 +25,16 @@ Extensible button component for the Core Email Components for composing campaign
 * Email subject, pre-header, plain text, and reference URL
 * Campaign variable access for many text fields
 
-## Use Object
-The Page component uses the following use objects:
+## Technical Details
 
-## Component Policy Configuration Properties
-The following configuration properties are used:
+This component inherit its structure and behavior from the [Button component (v2) of the `core.wcm.component`](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/button/v2/button) package. The only change is the integration of the personalization plugin, which results in the addition of a button to insert personalization fields from Adobe Campaign in the **Text** and **Link** fields in the following locations:
 
-## Edit Dialog Properties
-The following properties are written to JCR for this Page component and are expected to be available as `Resource` properties:
+* Configuration dialog toolbar
+* Full screen configuration dialog toolbar
+
+## Tests and Coverage
+
+The class `ButtonIT` is the Selenium test class. It checks for the existence of the personalization buttons in each of the previously mentioned windows.
 
 ## Information
 * **Vendor**: Adobe

--- a/content/src/content/jcr_root/apps/core/email/components/button/v1/button/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/button/v1/button/readme.md
@@ -17,6 +17,8 @@ limitations under the License.
 
 Extensible button component for the Core Email Components for composing campaign content written in HTL and based on the [Button Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/button/v2/button)
 
+The Button Component serves as a call-to-action link.
+
 ## Features
 
 * Supports editable templates

--- a/content/src/content/jcr_root/apps/core/email/components/container/v1/container/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/container/v1/container/readme.md
@@ -17,9 +17,11 @@ limitations under the License.
 
 Extensible container component for the Core Email Components for composing campaign content written in HTL and based on the [Container Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container)
 
+The Container Component provides a simplified responsive grid consisting of six columns.
+
 ## Features
 
-* Configurable layout with dropdown of different column split up options.
+* Configurable layout with dropdown of different column split up options
 * Extends the core container component
 
 ## Use Object

--- a/content/src/content/jcr_root/apps/core/email/components/container/v1/container/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/container/v1/container/readme.md
@@ -1,0 +1,55 @@
+<!--
+Copyright 2021 Adobe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+# Container Component
+
+Extensible container component for the Core Email Components for composing campaign content written in HTL and based on the [Container Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/container/v1/container)
+
+## Features
+
+* Configurable layout with dropdown of different column split up options.
+* Extends the core container component
+
+## Use Object
+
+The Container component uses the `com.adobe.cq.wcm.core.components.models.ContainerModel` Sling model as its Use-object.
+
+## Edit Dialog Properties
+
+The following properties are written to JCR for this Container component and are expected to be available as Resource properties:
+
+### Container Properties
+
+Defines the layout type with the column split up of either full-width, half; half, one-third; two-third, two-third; one-third and third; third; or third
+
+### Common Properties
+
+* `./backgroundImageReference` - defines the container background image
+* `./backgroundColor` - defines the container background color
+* `./id` - defines the component HTML ID attribute
+
+## Client Libraries
+
+The component provides a `core.email.components.container` client library category that contains a recommended base CSS styling component. It should be added to a relevant site client library using the embed property.
+
+When using a proxy component of the container, the `cq:template` folder from the container superType has to be copied.
+
+## Information
+* **Vendor**: Adobe
+* **Version**: v1
+* **Compatibility**: AEM 6.5
+* **Status**: production-ready
+* **User Documentation**: [https://www.adobe.com/go/aem_cmp_email_container_v1](https://www.adobe.com/go/aem_cmp_email_container_v1)
+* **Authors**: 

--- a/content/src/content/jcr_root/apps/core/email/components/container/v1/container/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/container/v1/container/readme.md
@@ -47,6 +47,7 @@ The component provides a `core.email.components.container` client library catego
 When using a proxy component of the container, the `cq:template` folder from the container superType has to be copied.
 
 ## Information
+
 * **Vendor**: Adobe
 * **Version**: v1
 * **Compatibility**: AEM 6.5

--- a/content/src/content/jcr_root/apps/core/email/components/contentfragment/v1/contentfragment/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/contentfragment/v1/contentfragment/readme.md
@@ -26,6 +26,7 @@ Extensible Content Fragment component for the Core Email Components for composin
 * Option to embed the CF as single element
 
 ## Information
+
 * **Vendor**: Adobe
 * **Version**: v1
 * **Compatibility**: AEM 6.5

--- a/content/src/content/jcr_root/apps/core/email/components/contentfragment/v1/contentfragment/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/contentfragment/v1/contentfragment/readme.md
@@ -17,6 +17,8 @@ limitations under the License.
 
 Extensible Content Fragment component for the Core Email Components for composing campaign content written in HTL and based on the [Content Fragment Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment)
 
+The Content Fragment Component allows embedding a Content Fragment in structured or text format in campaign content.
+
 ## Features
 
 * Displays the elements of a Content Fragment as an HTML description list

--- a/content/src/content/jcr_root/apps/core/email/components/contentfragment/v1/contentfragment/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/contentfragment/v1/contentfragment/readme.md
@@ -1,0 +1,34 @@
+<!--
+Copyright 2021 Adobe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+# Content Fragment Component
+
+Extensible Content Fragment component for the Core Email Components for composing campaign content written in HTL and based on the [Content Fragment Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/contentfragment/v1/contentfragment)
+
+## Features
+
+* Displays the elements of a Content Fragment as an HTML description list
+* By default, renders all elements of a Content Fragment
+* Alternative Content Fragment variations are configurable.
+* Capability to use the Campaign personalization fields in the RTE of the Content Fragment editor
+* Option to embed the CF as single element
+
+## Information
+* **Vendor**: Adobe
+* **Version**: v1
+* **Compatibility**: AEM 6.5
+* **Status**: production-ready
+* **User Documentation**: [https://www.adobe.com/go/aem_cmp_email_cf_v1](https://www.adobe.com/go/aem_cmp_email_cf_v1)
+* **Authors**: 

--- a/content/src/content/jcr_root/apps/core/email/components/experiencefragment/v1/experiencefragment/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/experiencefragment/v1/experiencefragment/readme.md
@@ -30,6 +30,7 @@ The following property is written to JCR for the experience fragment component a
 `./id` - defines the component HTML ID attribute
 
 ## Information
+
 * **Vendor**: Adobe
 * **Version**: v1
 * **Compatibility**: AEM 6.5

--- a/content/src/content/jcr_root/apps/core/email/components/experiencefragment/v1/experiencefragment/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/experiencefragment/v1/experiencefragment/readme.md
@@ -17,6 +17,8 @@ limitations under the License.
 
 Extensible Experience Fragment component for the Core Email Components for composing campaign content written in HTL and based on the [Experience Fragment Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v2/experiencefragment)
 
+The Experience Fragment Component allows embedding an Experience Fragment in campaign content.
+
 ## Features
 
 * Can be used on both templates and pages

--- a/content/src/content/jcr_root/apps/core/email/components/experiencefragment/v1/experiencefragment/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/experiencefragment/v1/experiencefragment/readme.md
@@ -1,0 +1,38 @@
+<!--
+Copyright 2021 Adobe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+# Experience Fragment Component
+
+Extensible Experience Fragment component for the Core Email Components for composing campaign content written in HTL and based on the [Experience Fragment Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/experiencefragment/v2/experiencefragment)
+
+## Features
+
+* Can be used on both templates and pages
+* Defines a configurable Experience Fragment variation to be displayed
+
+## Edit Dialog Properties
+
+The following property is written to JCR for the experience fragment component and is expected to be available as a Resource property:
+
+`./fragmentVariationPath` - defines the path to the experience fragment variation to be rendered.
+`./id` - defines the component HTML ID attribute
+
+## Information
+* **Vendor**: Adobe
+* **Version**: v1
+* **Compatibility**: AEM 6.5
+* **Status**: production-ready
+* **User Documentation**: [https://www.adobe.com/go/aem_cmp_email_xf_v1](https://www.adobe.com/go/aem_cmp_email_xf_v1)
+* **Authors**: 

--- a/content/src/content/jcr_root/apps/core/email/components/image/v1/image/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/image/v1/image/readme.md
@@ -14,9 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 # Image Component
+
 Extensible image component for the Core Email Components for composing campaign content written in HTL and based on the [Image Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image)
 
 ## Features
+
 * Linkable to content pages, external URLs or page anchors
 * Allows an icon identifier to be configured for rendering an icon
 * Personalization fields from Adobe Campaign
@@ -42,6 +44,7 @@ According to [statcounter,](https://gs.statcounter.com/screen-resolution-stats#m
 The `ImageIT` class is the Selenium test class. It verifies that the image renders correctly when a fixed width is selected and when the scale is set to full size. In both cases, it checks that the `src` HTML attribute of the image contains an absolute URL.
 
 ## Information
+
 * **Vendor**: Adobe
 * **Version**: v1
 * **Compatibility**: AEM 6.5

--- a/content/src/content/jcr_root/apps/core/email/components/image/v1/image/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/image/v1/image/readme.md
@@ -18,52 +18,40 @@ Image
 Image component written in HTL for rendering an adaptive image within campaign content based on the [Image Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image)
 
 ## Features
-* Native loading of optimal rendition
-* Scale image to to available width
-* Decorative-only images
-* Alternate text with option to get it from DAM
-* Image linking
+* Linkable to content pages, external URLs or page anchors
+* Allows an icon identifier to be configured for rendering an icon
+* Personalization fields from Adobe Campaign
 
 ## Use Object
-The Page component uses the following use objects:
-
-## Component Policy Configuration Properties
-The following configuration properties are used:
+The Button component uses the `com.adobe.cq.wcm.core.components.models.Button` Sling model as its Use-object.
 
 ## Edit Dialog Properties
-The following properties are written to JCR for this Page component and are expected to be available as `Resource` properties:
+The following properties are written to JCR for the Button component and are expected to be available as `Resource` properties:
 
-## Extending From This Component
-
-## URL Formats
-
-Images are loaded through the `com.adobe.cq.wcm.core.components.internal.servlets.AdaptiveImageServlet`, and therefore their URLs have the following patterns:
-
-```text
-Author:
-/content/<project_path>/<page_path>/<component_path>/<component_name>.coreimg.<quality>.<width>.<extension>/<timestamp>/<filename>.<extension>
-
-Publish:
-/content/<project_path>/<page_path>/<component_path>/<component_name>.coreimg.<quality>.<width>.<extension>/<timestamp>/<filename>.<extension>
-```
+`./jcr:title` - defines the button text
+`./link` - defines the button link
+`./linkTarget` - defines if the link should be opened in a new browser tab
+`./icon` - defines an icon identifier for rendering an icon
+`./accessibilityLabel` - defines an accessibility label for the button
+`./id` - defines the component HTML ID attribute
 
 ## BEM Description
 
 ```text
-BLOCK cmp-image
-    ELEMENT cmp-image__link
-    ELEMENT cmp-image__image
-    ELEMENT cmp-image__title
+BLOCK cmp-button
+    ELEMENT cmp-button__text
+    ELEMENT cmp-button__icon
+        MOD cmp-button__icon--<icon>
 ```
 
-## SVG
+## Icon Styling
 
-SVG MIME-types are supported, but have some specific handling. Alternative smart image widths defined at the component policy dialog are ignored for SVG images, with `Image#getWidths` returning an empty array.
+Icon styling must be done by users of the Email Core Components. Here's an example from the [Core Components Library.](https://github.com/adobe/aem-core-wcm-components/blob/72e2be7b9599aec7526be1adf3e4b3eaf3cf6f02/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/carousel/base.less#L145)
 
 ## Information
 * **Vendor**: Adobe
 * **Version**: v1
-* **Compatibility**: AEM 6.5, AEM as a Cloud Service
+* **Compatibility**: AEM 6.5
 * **Status**: production-ready
-* **User Documentation**: [https://www.adobe.com/go/aem_cmp_email_image_v1](https://www.adobe.com/go/aem_cmp_email_image_v1)
+* **User Documentation**: [https://www.adobe.com/go/aem_cmp_email_button_v1](https://www.adobe.com/go/aem_cmp_email_button_v1)
 * **Authors**: 

--- a/content/src/content/jcr_root/apps/core/email/components/image/v1/image/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/image/v1/image/readme.md
@@ -1,0 +1,69 @@
+<!--
+Copyright 2021 Adobe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+Image
+====
+Image component written in HTL for rendering an adaptive image within campaign content based on the [Image Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image)
+
+## Features
+* Native loading of optimal rendition
+* Scale image to to available width
+* Decorative-only images
+* Alternate text with option to get it from DAM
+* Image linking
+
+## Use Object
+The Page component uses the following use objects:
+
+## Component Policy Configuration Properties
+The following configuration properties are used:
+
+## Edit Dialog Properties
+The following properties are written to JCR for this Page component and are expected to be available as `Resource` properties:
+
+## Extending From This Component
+
+## URL Formats
+
+Images are loaded through the `com.adobe.cq.wcm.core.components.internal.servlets.AdaptiveImageServlet`, and therefore their URLs have the following patterns:
+
+```text
+Author:
+/content/<project_path>/<page_path>/<component_path>/<component_name>.coreimg.<quality>.<width>.<extension>/<timestamp>/<filename>.<extension>
+
+Publish:
+/content/<project_path>/<page_path>/<component_path>/<component_name>.coreimg.<quality>.<width>.<extension>/<timestamp>/<filename>.<extension>
+```
+
+## BEM Description
+
+```text
+BLOCK cmp-image
+    ELEMENT cmp-image__link
+    ELEMENT cmp-image__image
+    ELEMENT cmp-image__title
+```
+
+## SVG
+
+SVG MIME-types are supported, but have some specific handling. Alternative smart image widths defined at the component policy dialog are ignored for SVG images, with `Image#getWidths` returning an empty array.
+
+## Information
+* **Vendor**: Adobe
+* **Version**: v1
+* **Compatibility**: AEM 6.5, AEM as a Cloud Service
+* **Status**: production-ready
+* **User Documentation**: [https://www.adobe.com/go/aem_cmp_email_image_v1](https://www.adobe.com/go/aem_cmp_email_image_v1)
+* **Authors**: 

--- a/content/src/content/jcr_root/apps/core/email/components/image/v1/image/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/image/v1/image/readme.md
@@ -13,9 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-Image
-====
-Image component written in HTL for rendering an adaptive image within campaign content based on the [Image Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image)
+# Image
+Extensible image component for the Core Email Components for composing campaign content written in HTL and based on the [Image Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image)
 
 ## Features
 * Linkable to content pages, external URLs or page anchors

--- a/content/src/content/jcr_root/apps/core/email/components/image/v1/image/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/image/v1/image/readme.md
@@ -13,39 +13,33 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-# Image
+# Image Component
 Extensible image component for the Core Email Components for composing campaign content written in HTL and based on the [Image Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image)
 
 ## Features
 * Linkable to content pages, external URLs or page anchors
 * Allows an icon identifier to be configured for rendering an icon
 * Personalization fields from Adobe Campaign
+* Ability to define image width
 
-## Use Object
-The Button component uses the `com.adobe.cq.wcm.core.components.models.Button` Sling model as its Use-object.
+## Technical Details
 
-## Edit Dialog Properties
-The following properties are written to JCR for the Button component and are expected to be available as `Resource` properties:
+This component inherits its structure and behavior from the [Image (v3) component of the `core.wcm.component` package.](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image)
 
-`./jcr:title` - defines the button text
-`./link` - defines the button link
-`./linkTarget` - defines if the link should be opened in a new browser tab
-`./icon` - defines an icon identifier for rendering an icon
-`./accessibilityLabel` - defines an accessibility label for the button
-`./id` - defines the component HTML ID attribute
+The changes are:
 
-## BEM Description
+* Addition of the numeric field **Fixed width (px)** on the **Metadata** tab of the edit dialog, which defines the width (in pixels) of the image
+* Addition of the checkbox **Scale image to available width** on the **Metadata** tab of the edit dialog, which forces the image to be displayed in full screen mode
+* Addition of the numeric field **Default width (px)** in the edit template dialog, which defines the default value for **Fixed width (px)** field when no value is present
+* The image URL in the `src` HTML attribute is now absolute (see [UrlMapperService](https://github.com/adobe/aem-core-email-components/wiki/UrlMapperService:-Technical-documentation) for details)
 
-```text
-BLOCK cmp-button
-    ELEMENT cmp-button__text
-    ELEMENT cmp-button__icon
-        MOD cmp-button__icon--<icon>
-```
+## Best Practices for Email Image Sizes
 
-## Icon Styling
+According to [statcounter,](https://gs.statcounter.com/screen-resolution-stats#monthly-202201-202203) the most common resolutions (across all platforms) between January and March 2022 are 1920x1080 (9.04% to 9.43%) and 1366x768 (7.35% to 7.57%). Therefore the default width of the Image component is 1280.
 
-Icon styling must be done by users of the Email Core Components. Here's an example from the [Core Components Library.](https://github.com/adobe/aem-core-wcm-components/blob/72e2be7b9599aec7526be1adf3e4b3eaf3cf6f02/examples/ui.apps/src/content/jcr_root/apps/core-components-examples/clientlibs/clientlib-themes/core-components-clean/styles/components/carousel/base.less#L145)
+## Tests and Coverage
+
+The `ImageIT` class is the Selenium test class. It verifies that the image renders correctly when a fixed width is selected and when the scale is set to full size. In both cases, it checks that the `src` HTML attribute of the image contains an absolute URL.
 
 ## Information
 * **Vendor**: Adobe

--- a/content/src/content/jcr_root/apps/core/email/components/image/v1/image/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/image/v1/image/readme.md
@@ -17,6 +17,8 @@ limitations under the License.
 
 Extensible image component for the Core Email Components for composing campaign content written in HTL and based on the [Image Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/image/v3/image)
 
+The Image Component allows embedding images in campaign content.
+
 ## Features
 
 * Linkable to content pages, external URLs or page anchors

--- a/content/src/content/jcr_root/apps/core/email/components/page/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/page/readme.md
@@ -1,0 +1,43 @@
+<!--
+Copyright 2021 Adobe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+Page
+====
+Extensible page component for composing Campaign content written in HTL and based on the [Page Core Component](https://github.com/adobe/aem-core-wcm-components/blob/main/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/README.md)
+
+## Features
+* Supports editable templates
+* Title, description, tagging, and language definition
+* HTML ID
+* Cloud service configuration
+* Email subject, pre-header, plain text, and reference URL
+* Campaign variable access for many text fields
+
+## Use Object
+The Page component uses the following use objects:
+
+## Component Policy Configuration Properties
+The following configuration properties are used:
+
+## Edit Dialog Properties
+The following properties are written to JCR for this Page component and are expected to be available as `Resource` properties:
+
+## Information
+* **Vendor**: Adobe
+* **Version**: v1
+* **Compatibility**: AEM 6.5, AEM as a Cloud Service
+* **Status**: production-ready
+* **User Documentation**: [https://www.adobe.com/go/aem_cmp_email_page_v1](https://www.adobe.com/go/aem_cmp_email_page_v1)
+* **Authors**: 

--- a/content/src/content/jcr_root/apps/core/email/components/page/v1/page/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/page/v1/page/readme.md
@@ -13,7 +13,7 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-# Page
+# Page Component
 Extensible page component for the Core Email Components for composing campaign content written in HTL and based on the [Page Core Component](https://github.com/adobe/aem-core-wcm-components/blob/main/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/README.md)
 
 ## Features
@@ -23,18 +23,6 @@ Extensible page component for the Core Email Components for composing campaign c
 * Cloud service configuration
 * Email subject, pre-header, plain text, and reference URL
 * Campaign variable access for many text fields
-
-## Use Object
-The Page component uses the following use objects:
-
-* `com.adobe.cq.wcm.core.components.models.Page`
-* `com.day.cq.wcm.foundation.TemplatedContainer`
-
-## Component Policy Configuration Properties
-The following configuration properties are used:
-
-## Edit Dialog Properties
-The following properties are written to JCR for this Page component and are expected to be available as `Resource` properties:
 
 ## Information
 * **Vendor**: Adobe

--- a/content/src/content/jcr_root/apps/core/email/components/page/v1/page/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/page/v1/page/readme.md
@@ -15,7 +15,7 @@ limitations under the License.
 -->
 Page
 ====
-Extensible page component for composing Campaign content written in HTL and based on the [Page Core Component](https://github.com/adobe/aem-core-wcm-components/blob/main/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/README.md)
+Extensible page component written in HTL for composing campaign content and based on the [Page Core Component](https://github.com/adobe/aem-core-wcm-components/blob/main/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/README.md)
 
 ## Features
 * Supports editable templates

--- a/content/src/content/jcr_root/apps/core/email/components/page/v1/page/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/page/v1/page/readme.md
@@ -14,9 +14,11 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 # Page Component
+
 Extensible page component for the Core Email Components for composing campaign content written in HTL and based on the [Page Core Component](https://github.com/adobe/aem-core-wcm-components/blob/main/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/README.md)
 
 ## Features
+
 * Supports editable templates
 * Title, description, tagging, and language definition
 * HTML ID
@@ -25,6 +27,7 @@ Extensible page component for the Core Email Components for composing campaign c
 * Campaign variable access for many text fields
 
 ## Information
+
 * **Vendor**: Adobe
 * **Version**: v1
 * **Compatibility**: AEM 6.5

--- a/content/src/content/jcr_root/apps/core/email/components/page/v1/page/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/page/v1/page/readme.md
@@ -13,9 +13,8 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 -->
-Page
-====
-Extensible page component written in HTL for composing campaign content and based on the [Page Core Component](https://github.com/adobe/aem-core-wcm-components/blob/main/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/README.md)
+# Page
+Extensible page component for the Core Email Components for composing campaign content written in HTL and based on the [Page Core Component](https://github.com/adobe/aem-core-wcm-components/blob/main/content/src/content/jcr_root/apps/core/wcm/components/page/v3/page/README.md)
 
 ## Features
 * Supports editable templates

--- a/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/readme.md
@@ -1,0 +1,46 @@
+<!--
+Copyright 2021 Adobe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+# Segmentation Component
+Extensible segmentation component for the Core Email Components for composing campaign content written in HTL and based on the [Tabs Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs)
+
+## Features
+
+* Allows the creation of different containers for each segment and its content
+* Allowed components can be configured through policy configuration.
+* Navigation between container panels via the toolbar
+
+## Component Policy Configuration Properties
+
+The component policy dialog allows definition of allowed components for the Segmentation component.
+
+## Edit Dialog Properties
+
+The following properties are written to JCR for this Segmentation component and are expected to be available as `Resource` properties:
+
+* `./activeItem` - Defines the name of the item that is active by default
+* `./id` - Defines the component HTML ID attribute
+
+## Client Libraries
+
+The component provides a `core.wcm.components.tabs.v1 client` library category that contains a recommended base CSS styling. It should be added to a relevant site client library using the embed property.
+
+## Information
+* **Vendor**: Adobe
+* **Version**: v1
+* **Compatibility**: AEM 6.5
+* **Status**: production-ready
+* **User Documentation**: [https://www.adobe.com/go/aem_cmp_email_segmentation_v1](https://www.adobe.com/go/aem_cmp_email_segmentation_v1)
+* **Authors**: 

--- a/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/readme.md
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 # Segmentation Component
+
 Extensible segmentation component for the Core Email Components for composing campaign content written in HTL and based on the [Tabs Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs)
 
 ## Features
@@ -38,6 +39,7 @@ The following properties are written to JCR for this Segmentation component and 
 The component provides a `core.wcm.components.tabs.v1 client` library category that contains a recommended base CSS styling. It should be added to a relevant site client library using the embed property.
 
 ## Information
+
 * **Vendor**: Adobe
 * **Version**: v1
 * **Compatibility**: AEM 6.5

--- a/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/segmentation/v1/segmentation/readme.md
@@ -17,6 +17,8 @@ limitations under the License.
 
 Extensible segmentation component for the Core Email Components for composing campaign content written in HTL and based on the [Tabs Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/tabs/v1/tabs)
 
+The Segmentation Component presents content wrapped with a conditional statement which renders only when the condition is true.
+
 ## Features
 
 * Allows the creation of different containers for each segment and its content

--- a/content/src/content/jcr_root/apps/core/email/components/teaser/v1/teaser/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/teaser/v1/teaser/readme.md
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 # Teaser Component
+
 Extensible teaser component for the Core Email Components for composing campaign content written in HTL and based on the [Teaser Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser)
 
 ## Features
@@ -36,6 +37,7 @@ The Teaser also offers the capability to display the image as a background image
 The class `TeaserIT` is the Selenium test class. It checks for the existence of the personalization buttons in each of the previously mentioned windows.
 
 ## Information
+
 * **Vendor**: Adobe
 * **Version**: v1
 * **Compatibility**: AEM 6.5

--- a/content/src/content/jcr_root/apps/core/email/components/teaser/v1/teaser/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/teaser/v1/teaser/readme.md
@@ -17,6 +17,8 @@ limitations under the License.
 
 Extensible teaser component for the Core Email Components for composing campaign content written in HTL and based on the [Teaser Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser)
 
+The Teaser Component serves as a combination of title, text, image, and call-to-action.
+
 ## Features
 
 * Allows the creation of different containers for each segment and its content

--- a/content/src/content/jcr_root/apps/core/email/components/teaser/v1/teaser/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/teaser/v1/teaser/readme.md
@@ -1,0 +1,44 @@
+<!--
+Copyright 2021 Adobe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+# Teaser Component
+Extensible teaser component for the Core Email Components for composing campaign content written in HTL and based on the [Teaser Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser)
+
+## Features
+
+* Allows the creation of different containers for each segment and its content
+* Allowed components can be configured through policy configuration.
+* Navigation between container panels via the toolbar
+
+## Technical Details
+
+This component inherit its structure and behavior from the [Teaser component (v2) of the core.wcm.component package.](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/teaser/v2/teaser) The changes are the integration of the personalization plugin, which adds a button to insert Adobe Campaign personalization fields in the following locations:
+
+* Configuration dialog toolbar
+* Full screen configuration dialog toolbar
+
+The Teaser also offers the capability to display the image as a background image or as a regular image.
+
+## Tests and Coverage
+
+The class `TeaserIT` is the Selenium test class. It checks for the existence of the personalization buttons in each of the previously mentioned windows.
+
+## Information
+* **Vendor**: Adobe
+* **Version**: v1
+* **Compatibility**: AEM 6.5
+* **Status**: production-ready
+* **User Documentation**: [https://www.adobe.com/go/aem_cmp_email_segmentation_v1](https://www.adobe.com/go/aem_cmp_email_segmentation_v1)
+* **Authors**: 

--- a/content/src/content/jcr_root/apps/core/email/components/teaser/v1/teaser/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/teaser/v1/teaser/readme.md
@@ -40,5 +40,5 @@ The class `TeaserIT` is the Selenium test class. It checks for the existence of 
 * **Version**: v1
 * **Compatibility**: AEM 6.5
 * **Status**: production-ready
-* **User Documentation**: [https://www.adobe.com/go/aem_cmp_email_segmentation_v1](https://www.adobe.com/go/aem_cmp_email_segmentation_v1)
+* **User Documentation**: [https://www.adobe.com/go/aem_cmp_email_teaser_v1](https://www.adobe.com/go/aem_cmp_email_teaser_v1)
 * **Authors**: 

--- a/content/src/content/jcr_root/apps/core/email/components/text/v1/text/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/text/v1/text/readme.md
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 # Text Component
+
 Extensible text component for the Core Email Components for composing campaign content written in HTL and based on the [Text Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/text/v2/text)
 
 ## Features
@@ -38,6 +39,7 @@ There is some custom logic on the Java model class `com.adobe.cq.email.core.comp
 The class `EmailTextIt` is the Selenium test class. It checks for the existence of the personalization buttons in each of the previously mentioned windows.
 
 ## Information
+
 * **Vendor**: Adobe
 * **Version**: v1
 * **Compatibility**: AEM 6.5

--- a/content/src/content/jcr_root/apps/core/email/components/text/v1/text/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/text/v1/text/readme.md
@@ -1,0 +1,46 @@
+<!--
+Copyright 2021 Adobe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+# Text Component
+Extensible text component for the Core Email Components for composing campaign content written in HTL and based on the [Text Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/text/v2/text)
+
+## Features
+
+* Allows the creation of different containers for each segment and its content
+* Allowed components can be configured through policy configuration.
+* Navigation between container panels via the toolbar
+
+## Technical Details
+
+This component inherit its structure and behavior from the [Text component (v2) of the core.wcm.component package.](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/text/v2/text) The only change is the integration of the personalization plugin, which adds buttons to insert Adobe Campaign personalization fields in the following locations:
+
+* Inline editor toolbar
+* Full screen editor toolbar
+* Configuration dialog toolbar
+* Full screen configuration dialog toolbar
+
+There is some custom logic on the Java model class `com.adobe.cq.email.core.components.models.TextModel` related to link handling. Specifically, the `getText` method calls the `com.adobe.cq.email.core.components.util.HrefProcessor` utility class, which processes the actual content of Rich Text Component and looks for link elements. If they are present, it checks to see if the `href` attribute contains some URL-encoded Adobe Campaign markup. If so, it decodes it and adds the `x-cq-linkchecker="skip"` attribute to skip AEM link checker execution on that link.
+
+## Tests and Coverage
+
+The class `EmailTextIt` is the Selenium test class. It checks for the existence of the personalization buttons in each of the previously mentioned windows.
+
+## Information
+* **Vendor**: Adobe
+* **Version**: v1
+* **Compatibility**: AEM 6.5
+* **Status**: production-ready
+* **User Documentation**: [https://www.adobe.com/go/aem_cmp_email_text_v1](https://www.adobe.com/go/aem_cmp_email_text_v1)
+* **Authors**: 

--- a/content/src/content/jcr_root/apps/core/email/components/title/v1/title/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/title/v1/title/readme.md
@@ -14,6 +14,7 @@ See the License for the specific language governing permissions and
 limitations under the License.
 -->
 # Title Component
+
 Extensible title component for the Core Email Components for composing campaign content written in HTL and based on the [Text Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/title/v3/title)
 
 ## Features
@@ -34,6 +35,7 @@ This component inherit its structure and behavior from the [Title component (v3)
 The class `TitleIT` is the Selenium test class. It checks for the existence of the personalization buttons in each of the previously mentioned windows.
 
 ## Information
+
 * **Vendor**: Adobe
 * **Version**: v1
 * **Compatibility**: AEM 6.5

--- a/content/src/content/jcr_root/apps/core/email/components/title/v1/title/readme.md
+++ b/content/src/content/jcr_root/apps/core/email/components/title/v1/title/readme.md
@@ -1,0 +1,42 @@
+<!--
+Copyright 2021 Adobe
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+# Title Component
+Extensible title component for the Core Email Components for composing campaign content written in HTL and based on the [Text Core Component](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/title/v3/title)
+
+## Features
+
+* Allows the creation of different containers for each segment and its content
+* Allowed components can be configured through policy configuration.
+* Navigation between container panels via the toolbar
+
+## Technical Details
+
+This component inherit its structure and behavior from the [Title component (v3) of the `core.wcm.component` package.](https://github.com/adobe/aem-core-wcm-components/tree/main/content/src/content/jcr_root/apps/core/wcm/components/title/v3/title) The only change is the integration of the personalization plugin, which adds buttons to insert personalization fields from Adobe Campaign in the following locations:
+
+* Configuration dialog toolbar
+* Full screen configuration dialog toolbar
+
+## Tests and Coverage
+
+The class `TitleIT` is the Selenium test class. It checks for the existence of the personalization buttons in each of the previously mentioned windows.
+
+## Information
+* **Vendor**: Adobe
+* **Version**: v1
+* **Compatibility**: AEM 6.5
+* **Status**: production-ready
+* **User Documentation**: [https://www.adobe.com/go/aem_cmp_email_title_v1](https://www.adobe.com/go/aem_cmp_email_title_v1)
+* **Authors**: 


### PR DESCRIPTION
## Description

To bring the documentation of the Email Core Components in line with the Core Components, all content about the individual components in the GitHub wiki were moved to readme files for each component.

## Related Issue

CQDOC-19486

## Motivation and Context

Standardizes documentation across components projects so users can easily find content. Removes redundant and outdated content from GitHub wiki

## How Has This Been Tested?

No. But only readme files were added.

## Screenshots (if appropriate):

n/a

## Types of changes

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [x] Documentation

## Checklist:

- [x ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [ ] My code follows the code style of this project.
- [x ] My change requires a change to the documentation.
- [x ] I have updated the documentation accordingly.
- [x ] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
