### PR TITLE
fix: inplace editing and default style of text

### DIFF
--- a/content/src/content/jcr_root/apps/core/email/components/text/v1/text/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/email/components/text/v1/text/_cq_editConfig.xml
@@ -9,7 +9,7 @@
         <inplaceEditingConfig
             jcr:primaryType="nt:unstructured"
             disableXSSFiltering="{Boolean}true"
-            editElementQuery="table.cmp-text > tbody > tr > td">
+            editElementQuery="table.cmp-text > tbody > tr > td > div">
             <rtePlugins jcr:primaryType="nt:unstructured">
                 <personalizationplugin
                     jcr:primaryType="nt:unstructured"

--- a/content/src/content/jcr_root/apps/core/email/components/text/v1/text/_cq_editConfig.xml
+++ b/content/src/content/jcr_root/apps/core/email/components/text/v1/text/_cq_editConfig.xml
@@ -8,7 +8,8 @@
         editorType="text">
         <inplaceEditingConfig
             jcr:primaryType="nt:unstructured"
-            disableXSSFiltering="{Boolean}true">
+            disableXSSFiltering="{Boolean}true"
+            editElementQuery="table.cmp-text > tbody > tr > td">
             <rtePlugins jcr:primaryType="nt:unstructured">
                 <personalizationplugin
                     jcr:primaryType="nt:unstructured"

--- a/content/src/content/jcr_root/apps/core/email/components/text/v1/text/clientlibs/site/css/text.css
+++ b/content/src/content/jcr_root/apps/core/email/components/text/v1/text/clientlibs/site/css/text.css
@@ -17,6 +17,10 @@
 /* stylelint-disable */
 
 td.no-background {
-          background-color: transparent;
-        }
+    background-color: transparent;
+}
+
+.cmp-text p {
+    text-align: left;
+}
 /* stylelint-enable */

--- a/content/src/content/jcr_root/apps/core/email/components/text/v1/text/text.html
+++ b/content/src/content/jcr_root/apps/core/email/components/text/v1/text/text.html
@@ -22,7 +22,7 @@
     <tbody>
     <tr>
         <td class="no-background">
-            <p class="cmp-text__paragraph">${text @ context = 'unsafe'}</p>
+            <p class="cmp-text__paragraph" data-sly-unwrap="${textModel.isRichText}">${text @ context = 'unsafe'}</p>
         </td>
     </tr>
     </tbody>

--- a/content/src/content/jcr_root/apps/core/email/components/text/v1/text/text.html
+++ b/content/src/content/jcr_root/apps/core/email/components/text/v1/text/text.html
@@ -22,7 +22,9 @@
     <tbody>
     <tr>
         <td class="no-background">
-            <p class="cmp-text__paragraph" data-sly-unwrap="${textModel.isRichText}">${text @ context = 'unsafe'}</p>
+            <div data-sly-unwrap="${!wcmmode.edit}">
+                <p class="cmp-text__paragraph" data-sly-unwrap="${textModel.isRichText}">${text @ context = 'unsafe'}</p>
+            </div>
         </td>
     </tr>
     </tbody>


### PR DESCRIPTION
- align text left which is currently centered due to the `<center>` tag
- select only the td for inplace editing to not mess with the table markup
- unwrap surrounding paragraph for richtext.
