### PR TITLE
Fix for incorrect selector filtering

### DIFF
--- a/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/servlets/StylesInlinerServlet.java
+++ b/bundles/core/src/main/java/com/adobe/cq/email/core/components/internal/servlets/StylesInlinerServlet.java
@@ -69,7 +69,7 @@ public class StylesInlinerServlet extends SlingSafeMethodsServlet {
                          final SlingHttpServletResponse resp) throws ServletException, IOException {
         // prepare forward request and response
         String selectors = Arrays.stream(request.getRequestPathInfo().getSelectors())
-            .filter(selector -> !INLINE_STYLES_SELECTOR.equals(INLINE_STYLES_SELECTOR))
+            .filter(selector -> !INLINE_STYLES_SELECTOR.equals(selector))
             .collect(Collectors.joining("."));
         InlinerResponseWrapper responseWrapper = new InlinerResponseWrapper(resp);
         RequestDispatcherOptions options = new RequestDispatcherOptions();


### PR DESCRIPTION
This changes fix an issue in the predicate filter and enables the keeping of selectors that are not named inline-styles as the code was intended to do.

## Description

Fix predicate filter

## Related Issue
See https://github.com/adobe/aem-core-email-components/issues/260

## Motivation and Context

This change is needed to keep selectors that are not inline-styles as the code was intended to do

## How Has This Been Tested?

Call in the browser

## Screenshots (if appropriate):

## Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

- [ ] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
